### PR TITLE
main: Bring back search by appid

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -142,6 +142,7 @@ def load_appstream():
             p.set(f"apps:{appid}", json.dumps(apps[appid]))
             redis_search.add_document(
                 f"fts:{appid}",
+                appid=appid,
                 name=apps[appid]["name"],
                 summary=apps[appid]["summary"],
                 description=search_description,
@@ -286,6 +287,7 @@ def startup_event():
         try:
             redis_search.create_index(
                 [
+                    redisearch.TextField("appid"),
                     redisearch.TextField("name"),
                     redisearch.TextField("summary"),
                     redisearch.TextField("description", 0.2),


### PR DESCRIPTION
This restores previous behavior where users could search by appid, e.g. "sugarlabs", and it would bring all sugar applications.