### PR TITLE
apps: Treat limit as a range not as an offset

### DIFF
--- a/app/apps.py
+++ b/app/apps.py
@@ -397,7 +397,7 @@ def search(userquery: str):
 
 
 def get_recently_updated(limit: int = 100):
-    apps = db.redis_conn.zrevrange("recently_updated_zset", 0, limit)
+    apps = db.redis_conn.zrevrange("recently_updated_zset", 0, limit - 1)
     keys = (f"apps:{appid}" for appid in apps)
     ret = list_apps_summary(appids=keys, sort=False)
     return ret


### PR DESCRIPTION
ZREVRANGE [1] deals with ranges, so, the first element,
in our case 0, is already included:

ZREVRANGE recently_updated_zset 0 0 -> 1 element
ZREVRANGE recently_updated_zset 0 1 -> 2 elements
and so on...

[1] https://redis.io/commands/zrevrange

Closes #10