### PR TITLE
apps: Use actual icon name from app-info

### DIFF
--- a/app/apps.py
+++ b/app/apps.py
@@ -369,6 +369,7 @@ def search(userquery: str):
 
     # redisearch does not support fuzzy search for non-alphabet strings
     if userquery.isalpha():
+    if userquery.isalnum():
         generic_query = redisearch.Query(f"%{userquery}%").no_content()
     else:
         generic_query = redisearch.Query(userquery).no_content()

--- a/app/apps.py
+++ b/app/apps.py
@@ -47,8 +47,10 @@ def get_icon_path(app):
         if cached_icons:
             cached_icons.sort()
             size = cached_icons[0]
+            name = icons[0]["value"]
+
             icon_path = (
-                f"{cdn_baseurl}/repo/appstream/x86_64/icons/{size}x{size}/{appid}.png"
+                f"{cdn_baseurl}/repo/appstream/x86_64/icons/{size}x{size}/{name}"
             )
             return icon_path
 
@@ -369,7 +371,6 @@ def search(userquery: str):
 
     # redisearch does not support fuzzy search for non-alphabet strings
     if userquery.isalpha():
-    if userquery.isalnum():
         generic_query = redisearch.Query(f"%{userquery}%").no_content()
     else:
         generic_query = redisearch.Query(userquery).no_content()


### PR DESCRIPTION
Appstream is a gift that keeps on giving. appstream-compose sets the
icon name based on the value of <launchable> tag and not the name or ID
used by the referenced desktop file. The assumption that appid == icon
filename is wrong, even if happens to be true most of the time.

See https://github.com/flathub/flathub/pull/1949 for details.