### PR TITLE
Add additional addons by wildcard

### DIFF
--- a/app/apps.py
+++ b/app/apps.py
@@ -96,13 +96,24 @@ def get_category(category: str):
 
 
 def get_addons(appid: str):
+    result = []
+    if summary := db.get_json_key(f"summary:{appid}"):
+        extension_ids = list(summary["metadata"]["extensions"].keys())
+
+        apps = list_appstream(type="addon")
+
+        for app in apps:
+            for extension_id in extension_ids:
+                if app.startswith(extension_id):
+                    result.append(app)
+
     if index := db.redis_conn.smembers(f"addons:{appid}"):
         json_appdata = db.redis_conn.mget(index)
         appdata = [json.loads(app) for app in json_appdata]
 
-        return [(app["id"]) for app in appdata]
-    else:
-        return []
+        result.append((app["id"]) for app in appdata)
+
+    return result
 
 
 def search(query: str):

--- a/app/db.py
+++ b/app/db.py
@@ -127,4 +127,4 @@ def get_json_key(key: str):
 
 
 def get_app_count():
-    return redis_conn.scard("apps:index")
+    return redis_conn.scard("types:desktop")

--- a/app/main.py
+++ b/app/main.py
@@ -60,10 +60,12 @@ def get_addons(appid: str):
 
     addon_appstreams = defaultdict()
     for addonid in ids:
-        addon_appstreams[addonid] = db.get_json_key(f"apps:{addonid}")
+        if addon := db.get_json_key(f"apps:{addonid}"):
+            addon_appstreams[addonid] = addon
+
     sorted_ids = sorted(
         ids,
-        key=lambda appid: addon_appstreams[appid].get("name", "Unknown"),
+        key=lambda appid: addon_appstreams.get(appid, {}).get("name", "Unknown"),
     )
 
     return sorted_ids

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from functools import lru_cache
 
 import sentry_sdk
@@ -48,6 +49,21 @@ def get_category(category: schemas.Category):
             "downloads_last_month", 0
         ),
         reverse=True,
+    )
+
+    return sorted_ids
+
+
+@app.get("/addon/{appid}")
+def get_addons(appid: str):
+    ids = apps.get_addons(appid)
+
+    addon_appstreams = defaultdict()
+    for addonid in ids:
+        addon_appstreams[addonid] = db.get_json_key(f"apps:{addonid}")
+    sorted_ids = sorted(
+        ids,
+        key=lambda appid: addon_appstreams[appid].get("name", "Unknown"),
     )
 
     return sorted_ids

--- a/app/utils.py
+++ b/app/utils.py
@@ -35,8 +35,13 @@ def appstream2dict(reponame: str):
     for component in root:
         app = {}
 
-        if component.attrib.get("type") != "desktop":
+        if (
+            component.attrib.get("type") != "desktop"
+            and component.attrib.get("type") != "addon"
+        ):
             continue
+
+        app["type"] = component.attrib.get("type")
 
         descriptions = component.findall("description")
         if len(descriptions):

--- a/tests/results/test_appstream_by_appid.json
+++ b/tests/results/test_appstream_by_appid.json
@@ -1,4 +1,5 @@
 {
+  "type": "desktop",
   "description": "<p>Good at finding your way out of hard situations? Let's see! Try to make your way through an increasingly difficult path.</p>",
   "screenshots": [
     {
@@ -42,8 +43,12 @@
   "name": "Maze",
   "summary": "A simple maze game",
   "developer_name": "Sugar Labs Community",
-  "categories": ["Game"],
-  "kudos": ["HiDpiIcon"],
+  "categories": [
+    "Game"
+  ],
+  "kudos": [
+    "HiDpiIcon"
+  ],
   "project_license": "GPL-3.0-or-later",
   "launchable": {
     "value": "org.sugarlabs.Maze.desktop",


### PR DESCRIPTION
This needs to check the `autodelete` value on the extension too. I'm still not sure if we really want it, it ends up with fairly long lists, that has many addons that you can't install via gnome software for e.g. and some might have been autoinstalled (?)