### PR TITLE
verification: Add website verification

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -218,3 +218,8 @@ def get_verification_status(appid: str):
 @app.get("/verification/{appid}/available-methods", status_code=200)
 def get_verification_methods(appid: str):
     return verification.get_verification_methods(appid)
+
+
+@app.get("/verification/{appid}/website", status_code=200)
+def get_website_verification(appid: str):
+    return verification.get_website_verification(appid)

--- a/app/verification.py
+++ b/app/verification.py
@@ -61,6 +61,11 @@ def _get_domain_name(appid: str) -> str:
 
 
 def _check_app_id_error(appid: str) -> str:
+    if len(appid.split(".")) < 3:
+        return "malformed_app_id"
+    elif not re.match("[_\w\.]+$", appid):
+        return "malformed_app_id"
+
     try:
         r = requests.get(
             f"https://api.github.com/repos/flathub/{urllib.parse.quote(appid, safe='')}"
@@ -69,11 +74,6 @@ def _check_app_id_error(appid: str) -> str:
             return "repo_does_not_exist"
     except:
         return "error_connecting_to_github"
-
-    if len(appid.split(".")) < 3:
-        return "malformed_app_id"
-    elif not re.match("[_\w\.]+$", appid):
-        return "malformed_app_id"
 
     return None
 

--- a/app/verification.py
+++ b/app/verification.py
@@ -61,6 +61,19 @@ def _get_domain_name(appid: str) -> str:
 
 
 def _check_app_id_error(appid: str) -> str:
+    """
+    Returns an error detail if the app ID is invalid, or None if it is valid.
+
+    All error details, from this function and others:
+    - "malformed_app_id": The app ID is not syntactically correct
+    - "repo_does_not_exist": The app ID does not refer to an existing flathub repository.
+    - "error_connecting_to_github": The server could not connect to GitHub.
+    - "invalid_domain": Website verification was requested, but the app ID is not eligible for website verification.
+    - "failed_to_connect": The server could not connect to the website.
+    - "server_returned_error": The server got a non-200 status code from the website.
+    - "app_not_listed": The app ID is not listed in /.well-known/org.flathub.VerifiedApps.txt on the website.
+    - "blocked_by_admins": The app cannot be verified because the flathub administrators manually blocked it.
+    """
     if len(appid.split(".")) < 3:
         return "malformed_app_id"
     elif not re.match("[_\w\.]+$", appid):
@@ -115,6 +128,17 @@ def _check_website_verification(appid: str):
 
 
 def get_verification_methods(appid: str):
+    """
+    Gets a list of all available verification methods for an app.
+
+    Returns:
+    - "methods": An array of methods.
+      - "method": "website" or "login_provider"
+      - "website": For "website" method, the domain name for the website (e.g. flathub.org)
+      - "login_provider": For "login_provider" method. Currently only "GitHub".
+      - "login_name": For "login_provider" method. The username of the user who must verify the app.
+    - "detail": Error detail.
+    """
     if detail := _check_app_id_error(appid):
         return {
             "methods": [],
@@ -152,6 +176,15 @@ def get_verification_methods(appid: str):
 
 
 def get_verification_status(appid: str):
+    """
+    Gets the verification status of an app ID.
+
+    Returns:
+    - "verified": True or False
+    - "method": "none", "manual", or "website"
+    - "website": For "website" method, the domain name of the website that verified the app (e.g. "gnome.org").
+    - "detail": Error detail. See docs for _check_app_id_error().
+    """
     if detail := _check_app_id_error(appid):
         return {
             "verified": False,
@@ -185,6 +218,15 @@ def get_verification_status(appid: str):
 
 
 def get_website_verification(appid: str):
+    """
+    Returns information helpful for debugging the website verification process, such as what error occurred (if any)
+    and the status code received from the website.
+
+    Returns:
+    - "verified": True or False
+    - "detail": Error detail. See docs for _check_app_id_error().
+    - "status_code": The status code if "detail" is "server_returned_error".
+    """
     if detail := _check_app_id_error(appid):
         return {
             "verified": False,

--- a/app/verification.py
+++ b/app/verification.py
@@ -1,4 +1,6 @@
 import os
+import re
+import urllib.parse
 
 import requests
 
@@ -32,58 +34,161 @@ def initialize():
         p.execute()
 
 
-def get_verification_methods(appid: str):
-    segments = appid.split(".")
+def _matches_prefixes(appid: str, *prefixes) -> bool:
+    for prefix in prefixes:
+        if appid.startswith(prefix + "."):
+            return True
+    return False
 
-    if len(segments) < 3:
+
+def _get_github_username(appid: str) -> str:
+    if _matches_prefixes(appid, "com.github", "io.github"):
+        return appid.split(".")[2]
+    else:
+        return None
+
+
+def _get_domain_name(appid: str) -> str:
+    if _matches_prefixes(appid, "com.github", "com.gitlab"):
+        # These app IDs are common, and we don't want to confuse people by saying they can put a file on GitHub/GitLab's
+        # main website.
+        return None
+    elif _matches_prefixes(appid, "io.github", "io.gitlab"):
+        # You can, however, verify by putting a file on your *.github.io or *.gitlab.io site
+        return ".".join(reversed(appid.split(".")[0:3]))
+    else:
+        return ".".join(reversed(appid.split(".")[0:2]))
+
+
+def _check_app_id_error(appid: str) -> str:
+    try:
+        r = requests.get(
+            f"https://api.github.com/repos/flathub/{urllib.parse.quote(appid, safe='')}"
+        )
+        if r.status_code != 200:
+            return "repo_does_not_exist"
+    except:
+        return "error_connecting_to_github"
+
+    if len(appid.split(".")) < 3:
+        return "malformed_app_id"
+    elif not re.match("[_\w\.]+$", appid):
+        return "malformed_app_id"
+
+    return None
+
+
+def _check_website_verification(appid: str):
+    domain = _get_domain_name(appid)
+    if domain is None:
         return {
-            "methods": [],
-            "detail": "malformed_app_id",
+            "verified": False,
+            "detail": "invalid_domain",
         }
 
-    elif db.redis_conn.sismember("verification:blocked", appid):
+    try:
+        r = requests.get(
+            f"https://{domain}/.well-known/org.flathub.VerifiedApps.txt", timeout=5
+        )
+    except:
+        return {
+            "verified": False,
+            "detail": "failed_to_connect",
+        }
+
+    if r.status_code != 200:
+        return {
+            "verified": False,
+            "detail": "server_returned_error",
+            "status_code": r.status_code,
+        }
+
+    if appid in r.text.split("\n"):
+        return {
+            "verified": True,
+        }
+    else:
+        return {
+            "verified": False,
+            "detail": "app_not_listed",
+        }
+
+
+def get_verification_methods(appid: str):
+    if detail := _check_app_id_error(appid):
+        return {
+            "methods": [],
+            "detail": detail,
+        }
+
+    if db.redis_conn.sismember("verification:blocked", appid):
         return {
             "methods": [],
             "detail": "blocked_by_admins",
         }
 
-    elif segments[0:2] in [["com", "github"], ["io", "github"]]:
-        return {
-            "methods": [
-                {
-                    "method": "login_provider",
-                    "login_provider": "GitHub",
-                    "login_name": segments[2],
-                }
-            ]
-        }
+    methods = []
 
-    else:
-        return {
-            "methods": [
-                {
-                    "method": "website",
-                    "website": f"{segments[1]}.{segments[0]}",
-                }
-            ]
-        }
+    if domain := _get_domain_name(appid):
+        methods.append(
+            {
+                "method": "website",
+                "website": domain,
+            }
+        )
+
+    if github_name := _get_github_username(appid):
+        methods.append(
+            {
+                "method": "login_provider",
+                "login_provider": "GitHub",
+                "login_name": github_name,
+            }
+        )
+
+    return {
+        "methods": methods,
+    }
 
 
 def get_verification_status(appid: str):
+    if detail := _check_app_id_error(appid):
+        return {
+            "verified": False,
+            "method": "none",
+            "detail": detail,
+        }
+
     if db.redis_conn.sismember("verification:verified", appid):
         return {
             "verified": True,
             "method": "manual",
         }
 
-    elif db.redis_conn.sismember("verification:blocked", appid):
+    if db.redis_conn.sismember("verification:blocked", appid):
         return {
             "verified": False,
             "method": "manual",
         }
 
-    else:
+    if _check_website_verification(appid)["verified"]:
+        return {
+            "verified": True,
+            "method": "website",
+            "website": _get_domain_name(appid),
+        }
+
+    return {
+        "verified": False,
+        "method": "none",
+    }
+
+
+def get_website_verification(appid: str):
+    if detail := _check_app_id_error(appid):
         return {
             "verified": False,
-            "method": "none",
+            "detail": detail,
         }
+
+    return _check_website_verification(appid)

--- a/poetry.lock
+++ b/poetry.lock
@@ -323,6 +323,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "multidict"
+version = "6.0.2"
+description = "multidict implementation"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "mypy-extensions"
 version = "0.4.3"
 description = "Experimental type system extensions for programs checked with the mypy typechecker."
@@ -546,6 +554,14 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 six = ">=1.5"
 
 [[package]]
+name = "pyyaml"
+version = "6.0"
+description = "YAML parser and emitter for Python"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "redis"
 version = "3.5.3"
 description = "Python client for Redis key-value store"
@@ -745,6 +761,20 @@ h11 = ">=0.8"
 standard = ["httptools (>=0.2.0,<0.4.0)", "watchgod (>=0.6)", "python-dotenv (>=0.13)", "PyYAML (>=5.1)", "websockets (>=9.1)", "websockets (>=10.0)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1)", "colorama (>=0.4)"]
 
 [[package]]
+name = "vcrpy"
+version = "4.1.1"
+description = "Automatically mock your HTTP interactions to simplify and speed up testing"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+PyYAML = "*"
+six = ">=1.5"
+wrapt = "*"
+yarl = {version = "*", markers = "python_version >= \"3.6\""}
+
+[[package]]
 name = "watchgod"
 version = "0.7"
 description = "Simple, modern file watching and code reload in python."
@@ -759,6 +789,18 @@ description = "Module for decorators, wrappers and monkey patching."
 category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[[package]]
+name = "yarl"
+version = "1.7.2"
+description = "Yet another URL library"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+idna = ">=2.0"
+multidict = ">=4.0"
 
 [metadata]
 lock-version = "1.1"
@@ -1177,6 +1219,67 @@ mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
+multidict = [
+    {file = "multidict-6.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0b9e95a740109c6047602f4db4da9949e6c5945cefbad34a1299775ddc9a62e2"},
+    {file = "multidict-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ac0e27844758d7177989ce406acc6a83c16ed4524ebc363c1f748cba184d89d3"},
+    {file = "multidict-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:041b81a5f6b38244b34dc18c7b6aba91f9cdaf854d9a39e5ff0b58e2b5773b9c"},
+    {file = "multidict-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5fdda29a3c7e76a064f2477c9aab1ba96fd94e02e386f1e665bca1807fc5386f"},
+    {file = "multidict-6.0.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3368bf2398b0e0fcbf46d85795adc4c259299fec50c1416d0f77c0a843a3eed9"},
+    {file = "multidict-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f4f052ee022928d34fe1f4d2bc743f32609fb79ed9c49a1710a5ad6b2198db20"},
+    {file = "multidict-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:225383a6603c086e6cef0f2f05564acb4f4d5f019a4e3e983f572b8530f70c88"},
+    {file = "multidict-6.0.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:50bd442726e288e884f7be9071016c15a8742eb689a593a0cac49ea093eef0a7"},
+    {file = "multidict-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:47e6a7e923e9cada7c139531feac59448f1f47727a79076c0b1ee80274cd8eee"},
+    {file = "multidict-6.0.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:0556a1d4ea2d949efe5fd76a09b4a82e3a4a30700553a6725535098d8d9fb672"},
+    {file = "multidict-6.0.2-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:626fe10ac87851f4cffecee161fc6f8f9853f0f6f1035b59337a51d29ff3b4f9"},
+    {file = "multidict-6.0.2-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:8064b7c6f0af936a741ea1efd18690bacfbae4078c0c385d7c3f611d11f0cf87"},
+    {file = "multidict-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2d36e929d7f6a16d4eb11b250719c39560dd70545356365b494249e2186bc389"},
+    {file = "multidict-6.0.2-cp310-cp310-win32.whl", hash = "sha256:fcb91630817aa8b9bc4a74023e4198480587269c272c58b3279875ed7235c293"},
+    {file = "multidict-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:8cbf0132f3de7cc6c6ce00147cc78e6439ea736cee6bca4f068bcf892b0fd658"},
+    {file = "multidict-6.0.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:05f6949d6169878a03e607a21e3b862eaf8e356590e8bdae4227eedadacf6e51"},
+    {file = "multidict-6.0.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e2c2e459f7050aeb7c1b1276763364884595d47000c1cddb51764c0d8976e608"},
+    {file = "multidict-6.0.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d0509e469d48940147e1235d994cd849a8f8195e0bca65f8f5439c56e17872a3"},
+    {file = "multidict-6.0.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:514fe2b8d750d6cdb4712346a2c5084a80220821a3e91f3f71eec11cf8d28fd4"},
+    {file = "multidict-6.0.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:19adcfc2a7197cdc3987044e3f415168fc5dc1f720c932eb1ef4f71a2067e08b"},
+    {file = "multidict-6.0.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b9d153e7f1f9ba0b23ad1568b3b9e17301e23b042c23870f9ee0522dc5cc79e8"},
+    {file = "multidict-6.0.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:aef9cc3d9c7d63d924adac329c33835e0243b5052a6dfcbf7732a921c6e918ba"},
+    {file = "multidict-6.0.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:4571f1beddff25f3e925eea34268422622963cd8dc395bb8778eb28418248e43"},
+    {file = "multidict-6.0.2-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:d48b8ee1d4068561ce8033d2c344cf5232cb29ee1a0206a7b828c79cbc5982b8"},
+    {file = "multidict-6.0.2-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:45183c96ddf61bf96d2684d9fbaf6f3564d86b34cb125761f9a0ef9e36c1d55b"},
+    {file = "multidict-6.0.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:75bdf08716edde767b09e76829db8c1e5ca9d8bb0a8d4bd94ae1eafe3dac5e15"},
+    {file = "multidict-6.0.2-cp37-cp37m-win32.whl", hash = "sha256:a45e1135cb07086833ce969555df39149680e5471c04dfd6a915abd2fc3f6dbc"},
+    {file = "multidict-6.0.2-cp37-cp37m-win_amd64.whl", hash = "sha256:6f3cdef8a247d1eafa649085812f8a310e728bdf3900ff6c434eafb2d443b23a"},
+    {file = "multidict-6.0.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:0327292e745a880459ef71be14e709aaea2f783f3537588fb4ed09b6c01bca60"},
+    {file = "multidict-6.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e875b6086e325bab7e680e4316d667fc0e5e174bb5611eb16b3ea121c8951b86"},
+    {file = "multidict-6.0.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:feea820722e69451743a3d56ad74948b68bf456984d63c1a92e8347b7b88452d"},
+    {file = "multidict-6.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cc57c68cb9139c7cd6fc39f211b02198e69fb90ce4bc4a094cf5fe0d20fd8b0"},
+    {file = "multidict-6.0.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:497988d6b6ec6ed6f87030ec03280b696ca47dbf0648045e4e1d28b80346560d"},
+    {file = "multidict-6.0.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:89171b2c769e03a953d5969b2f272efa931426355b6c0cb508022976a17fd376"},
+    {file = "multidict-6.0.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:684133b1e1fe91eda8fa7447f137c9490a064c6b7f392aa857bba83a28cfb693"},
+    {file = "multidict-6.0.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fd9fc9c4849a07f3635ccffa895d57abce554b467d611a5009ba4f39b78a8849"},
+    {file = "multidict-6.0.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:e07c8e79d6e6fd37b42f3250dba122053fddb319e84b55dd3a8d6446e1a7ee49"},
+    {file = "multidict-6.0.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:4070613ea2227da2bfb2c35a6041e4371b0af6b0be57f424fe2318b42a748516"},
+    {file = "multidict-6.0.2-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:47fbeedbf94bed6547d3aa632075d804867a352d86688c04e606971595460227"},
+    {file = "multidict-6.0.2-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:5774d9218d77befa7b70d836004a768fb9aa4fdb53c97498f4d8d3f67bb9cfa9"},
+    {file = "multidict-6.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2957489cba47c2539a8eb7ab32ff49101439ccf78eab724c828c1a54ff3ff98d"},
+    {file = "multidict-6.0.2-cp38-cp38-win32.whl", hash = "sha256:e5b20e9599ba74391ca0cfbd7b328fcc20976823ba19bc573983a25b32e92b57"},
+    {file = "multidict-6.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:8004dca28e15b86d1b1372515f32eb6f814bdf6f00952699bdeb541691091f96"},
+    {file = "multidict-6.0.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2e4a0785b84fb59e43c18a015ffc575ba93f7d1dbd272b4cdad9f5134b8a006c"},
+    {file = "multidict-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6701bf8a5d03a43375909ac91b6980aea74b0f5402fbe9428fc3f6edf5d9677e"},
+    {file = "multidict-6.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a007b1638e148c3cfb6bf0bdc4f82776cef0ac487191d093cdc316905e504071"},
+    {file = "multidict-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:07a017cfa00c9890011628eab2503bee5872f27144936a52eaab449be5eaf032"},
+    {file = "multidict-6.0.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c207fff63adcdf5a485969131dc70e4b194327666b7e8a87a97fbc4fd80a53b2"},
+    {file = "multidict-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:373ba9d1d061c76462d74e7de1c0c8e267e9791ee8cfefcf6b0b2495762c370c"},
+    {file = "multidict-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bfba7c6d5d7c9099ba21f84662b037a0ffd4a5e6b26ac07d19e423e6fdf965a9"},
+    {file = "multidict-6.0.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:19d9bad105dfb34eb539c97b132057a4e709919ec4dd883ece5838bcbf262b80"},
+    {file = "multidict-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:de989b195c3d636ba000ee4281cd03bb1234635b124bf4cd89eeee9ca8fcb09d"},
+    {file = "multidict-6.0.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:7c40b7bbece294ae3a87c1bc2abff0ff9beef41d14188cda94ada7bcea99b0fb"},
+    {file = "multidict-6.0.2-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:d16cce709ebfadc91278a1c005e3c17dd5f71f5098bfae1035149785ea6e9c68"},
+    {file = "multidict-6.0.2-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:a2c34a93e1d2aa35fbf1485e5010337c72c6791407d03aa5f4eed920343dd360"},
+    {file = "multidict-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:feba80698173761cddd814fa22e88b0661e98cb810f9f986c54aa34d281e4937"},
+    {file = "multidict-6.0.2-cp39-cp39-win32.whl", hash = "sha256:23b616fdc3c74c9fe01d76ce0d1ce872d2d396d8fa8e4899398ad64fb5aa214a"},
+    {file = "multidict-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:4bae31803d708f6f15fd98be6a6ac0b6958fcf68fda3c77a048a4f9073704aae"},
+    {file = "multidict-6.0.2.tar.gz", hash = "sha256:5ff3bd75f38e4c43f1f470f2df7a4d430b821c4ce22be384e1459cb57d6bb013"},
+]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
@@ -1356,6 +1459,41 @@ python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
 ]
+pyyaml = [
+    {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
+    {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
+    {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
+    {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4"},
+    {file = "PyYAML-6.0-cp36-cp36m-win32.whl", hash = "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293"},
+    {file = "PyYAML-6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57"},
+    {file = "PyYAML-6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9"},
+    {file = "PyYAML-6.0-cp37-cp37m-win32.whl", hash = "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737"},
+    {file = "PyYAML-6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d"},
+    {file = "PyYAML-6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287"},
+    {file = "PyYAML-6.0-cp38-cp38-win32.whl", hash = "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78"},
+    {file = "PyYAML-6.0-cp38-cp38-win_amd64.whl", hash = "sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0"},
+    {file = "PyYAML-6.0-cp39-cp39-win32.whl", hash = "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb"},
+    {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
+    {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
+]
 redis = [
     {file = "redis-3.5.3-py2.py3-none-any.whl", hash = "sha256:432b788c4530cfe16d8d943a09d40ca6c16149727e4afe8c2c9d5580c59d9f24"},
     {file = "redis-3.5.3.tar.gz", hash = "sha256:0e7e0cfca8660dea8b7d5cd8c4f6c5e29e11f31158c0b0ae91a397f00e5a05a2"},
@@ -1446,6 +1584,10 @@ uvicorn = [
     {file = "uvicorn-0.16.0-py3-none-any.whl", hash = "sha256:d8c839231f270adaa6d338d525e2652a0b4a5f4c2430b5c4ef6ae4d11776b0d2"},
     {file = "uvicorn-0.16.0.tar.gz", hash = "sha256:eacb66afa65e0648fcbce5e746b135d09722231ffffc61883d4fac2b62fbea8d"},
 ]
+vcrpy = [
+    {file = "vcrpy-4.1.1-py2.py3-none-any.whl", hash = "sha256:12c3fcdae7b88ecf11fc0d3e6d77586549d4575a2ceee18e82eee75c1f626162"},
+    {file = "vcrpy-4.1.1.tar.gz", hash = "sha256:57095bf22fc0a2d99ee9674cdafebed0f3ba763018582450706f7d3a74fff599"},
+]
 watchgod = [
     {file = "watchgod-0.7-py3-none-any.whl", hash = "sha256:d6c1ea21df37847ac0537ca0d6c2f4cdf513562e95f77bb93abbcf05573407b7"},
     {file = "watchgod-0.7.tar.gz", hash = "sha256:48140d62b0ebe9dd9cf8381337f06351e1f2e70b2203fa9c6eff4e572ca84f29"},
@@ -1502,4 +1644,78 @@ wrapt = [
     {file = "wrapt-1.13.3-cp39-cp39-win32.whl", hash = "sha256:0a017a667d1f7411816e4bf214646d0ad5b1da2c1ea13dec6c162736ff25a374"},
     {file = "wrapt-1.13.3-cp39-cp39-win_amd64.whl", hash = "sha256:81bd7c90d28a4b2e1df135bfbd7c23aee3050078ca6441bead44c42483f9ebfb"},
     {file = "wrapt-1.13.3.tar.gz", hash = "sha256:1fea9cd438686e6682271d36f3481a9f3636195578bab9ca3382e2f5f01fc185"},
+]
+yarl = [
+    {file = "yarl-1.7.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f2a8508f7350512434e41065684076f640ecce176d262a7d54f0da41d99c5a95"},
+    {file = "yarl-1.7.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:da6df107b9ccfe52d3a48165e48d72db0eca3e3029b5b8cb4fe6ee3cb870ba8b"},
+    {file = "yarl-1.7.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a1d0894f238763717bdcfea74558c94e3bc34aeacd3351d769460c1a586a8b05"},
+    {file = "yarl-1.7.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dfe4b95b7e00c6635a72e2d00b478e8a28bfb122dc76349a06e20792eb53a523"},
+    {file = "yarl-1.7.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c145ab54702334c42237a6c6c4cc08703b6aa9b94e2f227ceb3d477d20c36c63"},
+    {file = "yarl-1.7.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1ca56f002eaf7998b5fcf73b2421790da9d2586331805f38acd9997743114e98"},
+    {file = "yarl-1.7.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1d3d5ad8ea96bd6d643d80c7b8d5977b4e2fb1bab6c9da7322616fd26203d125"},
+    {file = "yarl-1.7.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:167ab7f64e409e9bdd99333fe8c67b5574a1f0495dcfd905bc7454e766729b9e"},
+    {file = "yarl-1.7.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:95a1873b6c0dd1c437fb3bb4a4aaa699a48c218ac7ca1e74b0bee0ab16c7d60d"},
+    {file = "yarl-1.7.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:6152224d0a1eb254f97df3997d79dadd8bb2c1a02ef283dbb34b97d4f8492d23"},
+    {file = "yarl-1.7.2-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:5bb7d54b8f61ba6eee541fba4b83d22b8a046b4ef4d8eb7f15a7e35db2e1e245"},
+    {file = "yarl-1.7.2-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:9c1f083e7e71b2dd01f7cd7434a5f88c15213194df38bc29b388ccdf1492b739"},
+    {file = "yarl-1.7.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:f44477ae29025d8ea87ec308539f95963ffdc31a82f42ca9deecf2d505242e72"},
+    {file = "yarl-1.7.2-cp310-cp310-win32.whl", hash = "sha256:cff3ba513db55cc6a35076f32c4cdc27032bd075c9faef31fec749e64b45d26c"},
+    {file = "yarl-1.7.2-cp310-cp310-win_amd64.whl", hash = "sha256:c9c6d927e098c2d360695f2e9d38870b2e92e0919be07dbe339aefa32a090265"},
+    {file = "yarl-1.7.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:9b4c77d92d56a4c5027572752aa35082e40c561eec776048330d2907aead891d"},
+    {file = "yarl-1.7.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c01a89a44bb672c38f42b49cdb0ad667b116d731b3f4c896f72302ff77d71656"},
+    {file = "yarl-1.7.2-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c19324a1c5399b602f3b6e7db9478e5b1adf5cf58901996fc973fe4fccd73eed"},
+    {file = "yarl-1.7.2-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3abddf0b8e41445426d29f955b24aeecc83fa1072be1be4e0d194134a7d9baee"},
+    {file = "yarl-1.7.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6a1a9fe17621af43e9b9fcea8bd088ba682c8192d744b386ee3c47b56eaabb2c"},
+    {file = "yarl-1.7.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8b0915ee85150963a9504c10de4e4729ae700af11df0dc5550e6587ed7891e92"},
+    {file = "yarl-1.7.2-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:29e0656d5497733dcddc21797da5a2ab990c0cb9719f1f969e58a4abac66234d"},
+    {file = "yarl-1.7.2-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:bf19725fec28452474d9887a128e98dd67eee7b7d52e932e6949c532d820dc3b"},
+    {file = "yarl-1.7.2-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:d6f3d62e16c10e88d2168ba2d065aa374e3c538998ed04996cd373ff2036d64c"},
+    {file = "yarl-1.7.2-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:ac10bbac36cd89eac19f4e51c032ba6b412b3892b685076f4acd2de18ca990aa"},
+    {file = "yarl-1.7.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:aa32aaa97d8b2ed4e54dc65d241a0da1c627454950f7d7b1f95b13985afd6c5d"},
+    {file = "yarl-1.7.2-cp36-cp36m-win32.whl", hash = "sha256:87f6e082bce21464857ba58b569370e7b547d239ca22248be68ea5d6b51464a1"},
+    {file = "yarl-1.7.2-cp36-cp36m-win_amd64.whl", hash = "sha256:ac35ccde589ab6a1870a484ed136d49a26bcd06b6a1c6397b1967ca13ceb3913"},
+    {file = "yarl-1.7.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a467a431a0817a292121c13cbe637348b546e6ef47ca14a790aa2fa8cc93df63"},
+    {file = "yarl-1.7.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ab0c3274d0a846840bf6c27d2c60ba771a12e4d7586bf550eefc2df0b56b3b4"},
+    {file = "yarl-1.7.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d260d4dc495c05d6600264a197d9d6f7fc9347f21d2594926202fd08cf89a8ba"},
+    {file = "yarl-1.7.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fc4dd8b01a8112809e6b636b00f487846956402834a7fd59d46d4f4267181c41"},
+    {file = "yarl-1.7.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c1164a2eac148d85bbdd23e07dfcc930f2e633220f3eb3c3e2a25f6148c2819e"},
+    {file = "yarl-1.7.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:67e94028817defe5e705079b10a8438b8cb56e7115fa01640e9c0bb3edf67332"},
+    {file = "yarl-1.7.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:89ccbf58e6a0ab89d487c92a490cb5660d06c3a47ca08872859672f9c511fc52"},
+    {file = "yarl-1.7.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:8cce6f9fa3df25f55521fbb5c7e4a736683148bcc0c75b21863789e5185f9185"},
+    {file = "yarl-1.7.2-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:211fcd65c58bf250fb994b53bc45a442ddc9f441f6fec53e65de8cba48ded986"},
+    {file = "yarl-1.7.2-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:c10ea1e80a697cf7d80d1ed414b5cb8f1eec07d618f54637067ae3c0334133c4"},
+    {file = "yarl-1.7.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:52690eb521d690ab041c3919666bea13ab9fbff80d615ec16fa81a297131276b"},
+    {file = "yarl-1.7.2-cp37-cp37m-win32.whl", hash = "sha256:695ba021a9e04418507fa930d5f0704edbce47076bdcfeeaba1c83683e5649d1"},
+    {file = "yarl-1.7.2-cp37-cp37m-win_amd64.whl", hash = "sha256:c17965ff3706beedafd458c452bf15bac693ecd146a60a06a214614dc097a271"},
+    {file = "yarl-1.7.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:fce78593346c014d0d986b7ebc80d782b7f5e19843ca798ed62f8e3ba8728576"},
+    {file = "yarl-1.7.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c2a1ac41a6aa980db03d098a5531f13985edcb451bcd9d00670b03129922cd0d"},
+    {file = "yarl-1.7.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:39d5493c5ecd75c8093fa7700a2fb5c94fe28c839c8e40144b7ab7ccba6938c8"},
+    {file = "yarl-1.7.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1eb6480ef366d75b54c68164094a6a560c247370a68c02dddb11f20c4c6d3c9d"},
+    {file = "yarl-1.7.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5ba63585a89c9885f18331a55d25fe81dc2d82b71311ff8bd378fc8004202ff6"},
+    {file = "yarl-1.7.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e39378894ee6ae9f555ae2de332d513a5763276a9265f8e7cbaeb1b1ee74623a"},
+    {file = "yarl-1.7.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c0910c6b6c31359d2f6184828888c983d54d09d581a4a23547a35f1d0b9484b1"},
+    {file = "yarl-1.7.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6feca8b6bfb9eef6ee057628e71e1734caf520a907b6ec0d62839e8293e945c0"},
+    {file = "yarl-1.7.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:8300401dc88cad23f5b4e4c1226f44a5aa696436a4026e456fe0e5d2f7f486e6"},
+    {file = "yarl-1.7.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:788713c2896f426a4e166b11f4ec538b5736294ebf7d5f654ae445fd44270832"},
+    {file = "yarl-1.7.2-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:fd547ec596d90c8676e369dd8a581a21227fe9b4ad37d0dc7feb4ccf544c2d59"},
+    {file = "yarl-1.7.2-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:737e401cd0c493f7e3dd4db72aca11cfe069531c9761b8ea474926936b3c57c8"},
+    {file = "yarl-1.7.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:baf81561f2972fb895e7844882898bda1eef4b07b5b385bcd308d2098f1a767b"},
+    {file = "yarl-1.7.2-cp38-cp38-win32.whl", hash = "sha256:ede3b46cdb719c794427dcce9d8beb4abe8b9aa1e97526cc20de9bd6583ad1ef"},
+    {file = "yarl-1.7.2-cp38-cp38-win_amd64.whl", hash = "sha256:cc8b7a7254c0fc3187d43d6cb54b5032d2365efd1df0cd1749c0c4df5f0ad45f"},
+    {file = "yarl-1.7.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:580c1f15500e137a8c37053e4cbf6058944d4c114701fa59944607505c2fe3a0"},
+    {file = "yarl-1.7.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3ec1d9a0d7780416e657f1e405ba35ec1ba453a4f1511eb8b9fbab81cb8b3ce1"},
+    {file = "yarl-1.7.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3bf8cfe8856708ede6a73907bf0501f2dc4e104085e070a41f5d88e7faf237f3"},
+    {file = "yarl-1.7.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1be4bbb3d27a4e9aa5f3df2ab61e3701ce8fcbd3e9846dbce7c033a7e8136746"},
+    {file = "yarl-1.7.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:534b047277a9a19d858cde163aba93f3e1677d5acd92f7d10ace419d478540de"},
+    {file = "yarl-1.7.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c6ddcd80d79c96eb19c354d9dca95291589c5954099836b7c8d29278a7ec0bda"},
+    {file = "yarl-1.7.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:9bfcd43c65fbb339dc7086b5315750efa42a34eefad0256ba114cd8ad3896f4b"},
+    {file = "yarl-1.7.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f64394bd7ceef1237cc604b5a89bf748c95982a84bcd3c4bbeb40f685c810794"},
+    {file = "yarl-1.7.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:044daf3012e43d4b3538562da94a88fb12a6490652dbc29fb19adfa02cf72eac"},
+    {file = "yarl-1.7.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:368bcf400247318382cc150aaa632582d0780b28ee6053cd80268c7e72796dec"},
+    {file = "yarl-1.7.2-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:bab827163113177aee910adb1f48ff7af31ee0289f434f7e22d10baf624a6dfe"},
+    {file = "yarl-1.7.2-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:0cba38120db72123db7c58322fa69e3c0efa933040ffb586c3a87c063ec7cae8"},
+    {file = "yarl-1.7.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:59218fef177296451b23214c91ea3aba7858b4ae3306dde120224cfe0f7a6ee8"},
+    {file = "yarl-1.7.2-cp39-cp39-win32.whl", hash = "sha256:1edc172dcca3f11b38a9d5c7505c83c1913c0addc99cd28e993efeaafdfaa18d"},
+    {file = "yarl-1.7.2-cp39-cp39-win_amd64.whl", hash = "sha256:797c2c412b04403d2da075fb93c123df35239cd7b4cc4e0cd9e5839b73f52c58"},
+    {file = "yarl-1.7.2.tar.gz", hash = "sha256:45399b46d60c253327a460e99856752009fcee5f5d3c80b2f7c0cae1c38d56dd"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ alembic = "^1.7.5"
 psycopg2-binary = "^2.9.3"
 itsdangerous = "^2.0"
 PyGithub = "^1.55"
+vcrpy = "^4.1.1"
 
 [tool.poetry.dev-dependencies]
 black = "^21.12b0"

--- a/tests/cassettes/test_verification_available_method_github
+++ b/tests/cassettes/test_verification_available_method_github
@@ -59,7 +59,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 11 Feb 2022 17:58:21 GMT
+      - Mon, 14 Feb 2022 16:41:45 GMT
       ETag:
       - W/"ff4d4d98c4b09b9c5793380d76c04d981b8b0eee7845a98ae5052378c9cdc712"
       Last-Modified:
@@ -79,17 +79,17 @@ interactions:
       X-GitHub-Media-Type:
       - github.v3; format=json
       X-GitHub-Request-Id:
-      - E04C:0D67:263486E:4D7DA5B:6206A3BD
+      - 9970:2436:13EC53D:261A65D:620A8649
       X-RateLimit-Limit:
       - '60'
       X-RateLimit-Remaining:
-      - '49'
+      - '58'
       X-RateLimit-Reset:
-      - '1644605629'
+      - '1644860505'
       X-RateLimit-Resource:
       - core
       X-RateLimit-Used:
-      - '11'
+      - '2'
       X-XSS-Protection:
       - '0'
     status:

--- a/tests/cassettes/test_verification_available_method_github
+++ b/tests/cassettes/test_verification_available_method_github
@@ -1,0 +1,98 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.github.com/repos/flathub/com.github.bilelmoussaoui.Authenticator
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+1ZbW/bNhD+L/o6x/Jb28RA0Q3oVnRAFmDogK7DYFASbTGmRIGk7DlC/nufoyRL
+        9oD4peC3fGiaGLzn4R3vjsfHVSCSYD6evLl9N3n7bjIIcpXwBX0W3H/8dfsgf5fxp7sn9vXPTZyv
+        /7t//Gv2x9PnCf69D7CYZRwrY5UNV8KmZTSMhOQyU6UxTJVi+EtpU55bETOrNAyWpZSLxmopGZmE
+        51sXWmyYBeOSScMHgdrmXAfzKpBqJXJspIEEEXkwgUu3t9PbI6d2D+u73bfJbyX7WqTJJ7mJHj9P
+        7x//nj18vJ/BlIGD6UWpJRBTawszD8P6Q9O4WRquY5VbuDbE9sMybLk+bN4Txko3KC6S+OAIrRBt
+        wJw54EzYbT61mTzib8JLq7t1SyWl2sL2eLMvwId7IzoOByDy1eUAMKpChdNFpLD9Z3JaGHvRVpxB
+        FdJ/SDmCMIi85skl22lMsBnKhucq1LxQDquMTKxFYYXKL9rWgSGAlF6xXDyxi4FgaGBPG7poA84A
+        hnyDBLvIsraoQlcp8Y7CoHnMxQYxvRztyBRgdldQwT/0IkKRFpYvWJJRDbrSfB6gcM7I4QtqP+H7
+        wwzmOdoIZa9e73vBiwXmAtoWzgWkxHAi/ldBowgBjMit+c4LPuFWIX42dRWj0FmkNLVhL4QHBBVC
+        3PFRElrOMi+8DhgEqVJ+TsoBg0AYU/Kzaui6jHD4JmwLOC+zqO6q55TtdZQ1MnxjxohVzrmXE9qD
+        V+6eo2yINMvj1A9di12F9W8u+9jKi2uES+5IFXnBx6UfOvAqNCmrr1i78OUNsRH2AZnmS2+uEfae
+        zGpP+efcIvA9FSYGi1T04leLHVbNiUmWr0q28sO2B0cW0hy0Yk8np8HrekWHDioafbWISn+XSYdP
+        ntWDHPqhnyPr4DsyNzW+PIZeGcjeVOpCmWXi1Ix3HVMDfVDOHumozo4p6e/TI+z17hF2FXZ3ZX1J
+        N6w+Tq+5pVu/+tzNe9BLirbYYfVTgUcz3QTYQsE09+FkAx1WEcMoPxwOq5Qz9zzLuPbUyWpkUDAd
+        p3iu+PCrarExfWfMuqfiktxK8HSUiiVezm4PDqI6fXz4ViP387HAG8mLQw64z5RB8zFW5X7uuA69
+        z5krK5YkK51+3F/XXg4Iqg9G5DEfMDw7UXXQswTqEBIIZQ8eVtxPpGtkuA2ZjZg0lxwl6eVUW+wq
+        rJWYhBdS7bx17x48NTPNoeslC2YhLkxG49ub0fRmfPdlPJvPxvPR7BvWlEXSXzMZ34wmN6Pxl/F4
+        jmWjt7SmKE3awRwsmc6n72gJrqmm/vAbhL3/C2vn6gOk4AHQmLQD/LmDm1+obzZwsUQhHXWIH9/j
+        5niWuR4SLqcq4wVm2p4+2jg7hOQVsqIwYcItE9KcG0wKpHgC4pvpwSgbqzJHUkwGwZZZvBkxAnYf
+        teNvKwilzCzqRhjMrS6hENMnhVaPPLZmLxXRh11X7q3cirU4sKS5fW9Wi0EN+wiXodBaNTpxLUg1
+        9wsk35o9EYZFkuPvVrAueN7ssHVjjAYiYp4b+N6gkCa7IDY0mBZKmIXlWQHJvJO/rSpEjP398+8g
+        2AgjoL0Lu8OhFGUETIS0lpnm2KzqmCH3d9F0oU34kpXSLuoXMwAyZiyUddJtsmJRp6RVaw59r95j
+        XxJ9FeBPvUsO9P1XAd59n/LSVxSvAnzz1diPCPA5t1v0kLbPoAf039FNG5s+fwcqe7mPARwAAA==
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Cache-Control:
+      - public, max-age=60, s-maxage=60
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1309'
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 11 Feb 2022 17:58:21 GMT
+      ETag:
+      - W/"ff4d4d98c4b09b9c5793380d76c04d981b8b0eee7845a98ae5052378c9cdc712"
+      Last-Modified:
+      - Mon, 01 Feb 2021 11:14:06 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept, Accept-Encoding, Accept, X-Requested-With
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v3; format=json
+      X-GitHub-Request-Id:
+      - E04C:0D67:263486E:4D7DA5B:6206A3BD
+      X-RateLimit-Limit:
+      - '60'
+      X-RateLimit-Remaining:
+      - '49'
+      X-RateLimit-Reset:
+      - '1644605629'
+      X-RateLimit-Resource:
+      - core
+      X-RateLimit-Used:
+      - '11'
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_verification_available_method_multiple
+++ b/tests/cassettes/test_verification_available_method_multiple
@@ -1,0 +1,98 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.github.com/repos/flathub/io.github.lainsce.Notejot
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2ZUW/bNhCA/4te55qJnSaxgKJ76FZ0QBJg6EPXYRAoiZZoU6JAUjZsIf+9dxRl
+        yR5qyxsf89ImAu+745F3vLs0AU+DcD6f3d8/Lh7mk6CUKYvwW/D06bfti/hDJJ8Xe/rtz01SrvdP
+        +y+z51X2/nn/9CGAxbRgsJLLacZNXsdTQXmpEzZ9loatpIEly1qIyK1bCoqryLn1leIbaoC6pEKz
+        SSC3JVNB2ARCZrwEZQ4CaLRy9jC7f3ycP54YvntZL3bfZ7/X9FuVp5/FJl59mT+t/rp7+fR0B6IU
+        dFAV1UoAMTem0iEh7Uft9lJrphJZGlaaaSILUpNO18fNB2RkylGst+DDCa3inVesOOA06Y3PTSFO
+        9Dsf4up+3VIKIbcge2rsGTw5COEBWAAvs+sBINQQaXIGngLzX3HTXJurTLECDcH/4FohQoPnFUuv
+        MceJgDF4G14bolglLauOdaJ4ZbgsrzLrSBBAUmW05Ht6NQgENcijQVcZYAVAkG3ggl0l2Uo0xEZK
+        skM3KJYwvgGfXk87EQWY2VUY1C8Dj6CnuWERTQuMQRuarxMInBF3+Gy0p+xwfEFYQqrA+6rWh+g/
+        G1LWhV2onFWDzAs+HgmD0AIU+GPNdp6ISGoI/OviI4GApbFU1MhLUT/W6CNkQ4a/4vUxjBaeNmNR
+        gMyl9OVxiwIk17pmo274WLdYoiZdQJV1EbdZbkwYjVXSssB+qjXPSsY8efqAa+zbgucYK1omuS8F
+        Ha0h7U/2ptDMk/lIQpOFjD0R4fkkFtcQndP2sTKRP4uRj7QjvGJLj+Yj7YA3yttdsaYj7gCHF9XA
+        tfFke0cjjfO8oGVW08wX/4CDG4O1QEb3FyuisfHZ8wCOBZ/ice0z9fZEtL4tWCDP+HJ9D+zxth46
+        X2CNds+gwrIOKgp+qV4Zy3awo4DyqgDv/akS/P1yyXXNFpDWkP71aB8qp8fPKbiXqrN9qM31KJ6u
+        U0cjzS8VNGuYRUFpRRXzsxEHI01MoYScTqdNzqhtCwqmvOWLlgVQqpIcCmM/tjcdDWrAghrbhizR
+        9BTaEiFp6ukMDjhAtwfvx/6WNbw7FVTcnoy2qCG74IJpI0tfb0DPG2oppeFLnozp28aG9BGy+ah5
+        mbAJhdYEosDwhENcQGOM5w5lOvPlv5YFW4ORCrIVEwxCxNPpdLSGtD14yiohdx7z4ACIKUMxmOGk
+        ETXQSM5uZrfvbm7fzd5/vXkI7x7C+eN3WFNX6cmaW1iz+HozD+eL8G6Ba6pa50eYoyX3uARSvIsO
+        +AmGOP8eovy8M8T5DCC0znvErz0gvDivcoBEwDU/idH/Ysfm9M2+BgIbyWXBKqi6BjMtt4UpjCkI
+        rSpNUmYoF/rnTkGH8D0wZjBUGxRbiaxLOM6bSbClBroMKGD6T12B1jXxOdVRm26C0Kga5nj4pVJy
+        xRKjD+09fuyz3WDllq/5kSTWkgextp132m/h6eBKSTfNa4cILlPDYM6NEVOuaSxY/0FWrHQmDvfB
+        E1Zq2LzD4OgsQnUQ8Z09XEeGFRXMMvsppZEVT8DAv/+ZBBuuecwFNzs4h6qOBU/Ap+3cIARrB5qP
+        3Gl/SdmS1sJEbcsFgIJqAwNQbNKLKmpvmpFrBmOY1sbh5OptTnqprD4aw77NSe3Y+9wk+W1O6v5m
+        8X/mpCUzW8ghXZ6BHDBsA10eu3v9Abku21eMGQAA
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Cache-Control:
+      - public, max-age=60, s-maxage=60
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1284'
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 11 Feb 2022 17:58:22 GMT
+      ETag:
+      - W/"f2f7bc63540e416be0ad6cd1f70fd96a727eb90786a29212599ba2e34f1c8060"
+      Last-Modified:
+      - Mon, 29 Nov 2021 03:39:49 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept, Accept-Encoding, Accept, X-Requested-With
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v3; format=json
+      X-GitHub-Request-Id:
+      - E04E:3627:2181DE7:48A831B:6206A3BE
+      X-RateLimit-Limit:
+      - '60'
+      X-RateLimit-Remaining:
+      - '48'
+      X-RateLimit-Reset:
+      - '1644605630'
+      X-RateLimit-Resource:
+      - core
+      X-RateLimit-Used:
+      - '12'
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_verification_available_method_multiple
+++ b/tests/cassettes/test_verification_available_method_multiple
@@ -59,7 +59,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 11 Feb 2022 17:58:22 GMT
+      - Mon, 14 Feb 2022 16:41:45 GMT
       ETag:
       - W/"f2f7bc63540e416be0ad6cd1f70fd96a727eb90786a29212599ba2e34f1c8060"
       Last-Modified:
@@ -79,17 +79,17 @@ interactions:
       X-GitHub-Media-Type:
       - github.v3; format=json
       X-GitHub-Request-Id:
-      - E04E:3627:2181DE7:48A831B:6206A3BE
+      - 9972:7BCB:14B4FDF:26D9E24:620A8649
       X-RateLimit-Limit:
       - '60'
       X-RateLimit-Remaining:
-      - '48'
+      - '57'
       X-RateLimit-Reset:
-      - '1644605630'
+      - '1644860504'
       X-RateLimit-Resource:
       - core
       X-RateLimit-Used:
-      - '12'
+      - '3'
       X-XSS-Protection:
       - '0'
     status:

--- a/tests/cassettes/test_verification_available_method_website
+++ b/tests/cassettes/test_verification_available_method_website
@@ -1,0 +1,98 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.github.com/repos/flathub/org.gnome.Maps
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2YTW/jNhCG/4uu9Zr+WDeJgMX2kO2iBbwBihy2WxQGJdEWY0oUSMquI+S/70tR
+        smSnkGPwmktiy5yHw+HMaGaqgCdBOJ3c3S7mk8V0FOQyYSv7LFjef9k/iD9F/PXumX7/axfn2/+W
+        99uP3x6X+2+PXz4FWEwzhpVSbcabXGZsvKSFxvN1KcSq+XEtqEnLiLxaVCi+owbyayo0GwVynzMV
+        hFUg5IbnwDaS4Fl9ZjezX29v57dnKh4etneHH7PfS/q9SJOvYhc9/TFfPv398eF++RGiFHtQtSqV
+        ADE1ptAhIe6hHm+4Va3UTMUyNyw341hmpCTtXp93nyxjoxpKbRc8OKMVvCE5ceA06ZRPTSbO9nf7
+        1qu7dWsphNxD9lzZATw5Clmr1wCeb64HQKgi0qQMloL6L/bQXJurVKkFKmL/wYEsQsPyiiXXqNOI
+        QBnrDS8VUayQNauMdKx4YbjMr1LrRBAg+CHN+TO9GgRB69tWoasUqAUgyHZwsKsknURF6kiJD9YM
+        isWM72DT62lnooCZQ2HD96FnEWtpbtiKJpmNwTo0X0YInDf48OsQT9jxzoIwR1KwTqq2x5AfjKPa
+        bm18vGZb0AVrDhEQOZDHcbfs4IOx4hXB38bnYwQhjaSiRl6K5EH1TjgV6X+1fmAYzXzUruXBSaX0
+        smItDw7XumRvcsrBU9cYTVrHz8ssctnoLe4+SHYAaEq15pucMR/rHRkVadNlpGgep17UFlER96m+
+        Z7rxUdSKgxIJGflg8L4iNaMiOqXu7WBWnrpZqEWcMBVb+ypqEUemUX43XStpGUci3lAGl+6jZYsg
+        VWNNQfNNSTde0CPDpnC8eDf0+WItMRgxHQREWx8pHpXeWa3DWD3dSx0x7mXOjtIx60JhuPIYPn2v
+        3qjPn2X80tt7ENgQTrzdn2r985xsv18uNS4qaxEV6VKwS/EN3MOyTY5vtexv0VThPs7QIkj1S4HG
+        w+Yq7FRQxTxUbgikiijKofF4XKWM1iVuxpRf2DoASFTFKSo7Dy2rFoHSJqOmLp7XVskExbSQNPGx
+        65EBnrtBD00doH/zBYpDH/Vq+T4w44JpI3OvnNpB+uhcGr7m8Vs6iMEgO+FUnzXPYzaiKJLhrYbH
+        HP6LvsxeICpK5mUeB8Ah0LC7NkIwuLKPxRVziIq4Zi9hhZAH38TTo9jIVQwTgmRFDdqU2WR682E6
+        /TC5eZwuwtksnMx/YE1ZJP01s2m9ZvaIBVg2mdo1RanTDjOb4XesepxOwvlNuLixS5BIG4fGJ4wI
+        XrfoZy2Ibfkhp3Xayf3WSYX/P/dopGIBzzwLoDfvuDt/r12UhJ4pxjMFSozeFKTRcIzGltCi0CRh
+        hnKhX/damj9DcLE4qSxiWea4l9ko2FOD0hfv8O5RW420bV9K9cpFfRAaVWLcY58USj6x2OhjQ2gf
+        dpmmt3LPt/xklT1LJ+eawWZ7qJlxpWQz9XF9Z5MbMcBpxk0J1zQSrHsgC5Y3OvYPwmOWa5y+wdgR
+        y8puh9Bsj8L1yrCswKCrm2YZWfAYCv7z7yjYcc0jLrg5wPpFGQke40ZcAxpC297OJ/asvyRsTUth
+        Vq4nACCj2mBQZnvArFg5TzJyy9CuOx37E473edql0tI2cN2Y4X2eZsejQxPH93laM9D2maflzOyR
+        Q9o8YxNrrxVq8tj85SehO7WinhcAAA==
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Cache-Control:
+      - public, max-age=60, s-maxage=60
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1276'
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 11 Feb 2022 17:58:21 GMT
+      ETag:
+      - W/"6d687564288cb41a21e34e7d8c96428ef3004c993c6f3efd7c0fa58549f4f631"
+      Last-Modified:
+      - Tue, 02 Nov 2021 22:15:01 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept, Accept-Encoding, Accept, X-Requested-With
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v3; format=json
+      X-GitHub-Request-Id:
+      - E04A:1F9B:2FCEA3F:712294C:6206A3BD
+      X-RateLimit-Limit:
+      - '60'
+      X-RateLimit-Remaining:
+      - '50'
+      X-RateLimit-Reset:
+      - '1644605629'
+      X-RateLimit-Resource:
+      - core
+      X-RateLimit-Used:
+      - '10'
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_verification_status
+++ b/tests/cassettes/test_verification_status
@@ -1,0 +1,69 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.github.com/repos/flathub/com.github.flathub.ExampleApp
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAx3JQQqAIBBG4avEtK3cd4CWXSHMJhPSCed3EdHdkzaPD95DkVWtZxppFjSTlLRR
+        R5u4EjnBIkhaSj7rP4BLR2Pq08EHHGUdnESTWVGzc+bkuOoSbT2jt/3vAMk3vR/3hhbbawAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '112'
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 11 Feb 2022 17:58:21 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v3; format=json
+      X-GitHub-Request-Id:
+      - E048:3628:2F2049F:64452F1:6206A3BD
+      X-RateLimit-Limit:
+      - '60'
+      X-RateLimit-Remaining:
+      - '51'
+      X-RateLimit-Reset:
+      - '1644605629'
+      X-RateLimit-Resource:
+      - core
+      X-RateLimit-Used:
+      - '9'
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/tests/cassettes/test_verification_status_dne
+++ b/tests/cassettes/test_verification_status_dne
@@ -34,7 +34,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 11 Feb 2022 17:58:21 GMT
+      - Mon, 14 Feb 2022 16:41:45 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -50,17 +50,17 @@ interactions:
       X-GitHub-Media-Type:
       - github.v3; format=json
       X-GitHub-Request-Id:
-      - E048:3628:2F2049F:64452F1:6206A3BD
+      - 9974:5A9C:66F178:102AE09:620A8649
       X-RateLimit-Limit:
       - '60'
       X-RateLimit-Remaining:
-      - '51'
+      - '56'
       X-RateLimit-Reset:
-      - '1644605629'
+      - '1644860504'
       X-RateLimit-Resource:
       - core
       X-RateLimit-Used:
-      - '9'
+      - '4'
       X-XSS-Protection:
       - '0'
     status:

--- a/tests/cassettes/test_verification_status_invalid
+++ b/tests/cassettes/test_verification_status_invalid
@@ -1,0 +1,69 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.github.com/repos/flathub/com.github
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAx3JQQqAIBBG4avEtK3cd4CWXSHMJhPSCed3EdHdkzaPD95DkVWtZxppFjSTlLRR
+        R5u4EjnBIkhaSj7rP4BLR2Pq08EHHGUdnESTWVGzc+bkuOoSbT2jt/3vAMk3vR/3hhbbawAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '112'
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 14 Feb 2022 16:41:46 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v3; format=json
+      X-GitHub-Request-Id:
+      - 8F30:6825:B7940E:18DB417:620A864A
+      X-RateLimit-Limit:
+      - '60'
+      X-RateLimit-Remaining:
+      - '55'
+      X-RateLimit-Reset:
+      - '1644860505'
+      X-RateLimit-Resource:
+      - core
+      X-RateLimit-Used:
+      - '5'
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/tests/cassettes/test_verification_status_not_verified
+++ b/tests/cassettes/test_verification_status_not_verified
@@ -1,0 +1,435 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://api.github.com/repos/flathub/org.gnome.Calendar
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+2Y3W7jNhCFX6XQbR3TP9k4ERBsgWYbtEA2QLEX2y0KgZJoizElCiRlwxHy7j0U
+        JUt208iGchkgSGyF8/FoNDMaTunx2PNvrheXl9PFYuRlMmaBveQ93H3ZPoo/RHR/80y//7mJsvWn
+        x7to8vXuy/zr9vbWw2KaMqyUajVeZTJl41+pYFlMFf63LIQI6gVLQU1ShOTVhbniG2rAWVKh2ciT
+        24wpzy89IVc8A762BtPqmi1mV9fX8+sjqbvH9c3ux+y3gn7Pk/hebMKn3+cPT39dPt49XMKUYg+q
+        gkIJEBNjcu0T4i7q8YpbeYVmKpKZYZkZRzIlBWn2+ry5tYyVqimVf3DhiJbzmuTMgdOkFZ+YVBzt
+        7/atVrfrllIIuYXtsdg38GRvZD1fAXi2Oh8Ao5JIkzB4CvJf7E1zbc6SUhmUxP5BIFmEhucVi8+R
+        U5tAjI2Gl5IolsuKVYQ6Ujw3XGZnyTowBAixSDP+TM8GwVDD3go6S0BlAEO2QYCdZeksSlJlSrSz
+        blAsYnwDn55POzIFzOxym8aPHY9YT3PDAhqnNger1HwZIXFOiOHX0zxm++eGve5tufipWy6kWu9L
+        wJt5VfmxyZfX91oC1uPhPgoyCgy4Yc12Q1EWURL8rvMhQoLSUCpqZF+W98o8YJWk+9XGiWE0HSq/
+        YoCVSDnYqxUDLK51wU4K3l4PVChNmiTJijR0leuU1OilOwgUU635KmNsqDf3nJI0JTZUNIuSweQG
+        UxL3qXr+dDVUsEWAFAoZDkXhfUcqTkl0Qt3bxQTvoNGCLeaAq9jyPQRbzJ5r1PAIqMRazp6Kt51B
+        MAxV22BIWXtX0GxV0NVg8J5jXwt4ma/oc29/0ptZLQhU23cpHhbvUhFblNXrGgbUhMHubUktt2pE
+        3u5s+j3R6WkqX6Qp7+sQeqE15SAj3ods4/eYbr/3tzUnibaYkrRl3L0q6g0Gerp+VzRqu9vUnf/Q
+        IGkwpPw5x6HH1jjsllPFBkqvKaQMKVqx8XhcJoxW7XXK1PAUdxDQqIoSdJYD1ZYNBm1USk3VwC+t
+        2BgNvZA0HurnPQdM91QHKnaQbkTkOMEOlVkxutCUC6aNzAbX5BbUxWfS8CWPTjnV9CbjAav8rHkW
+        sREVYoRoNjziiG+cF+1DRTfLBrvKQXAzGCq4I45gCPWhT0AxhymJO4zGLBdy9x7FqkOyWa4Yphhx
+        QA2ON7PJdHExWVzMbr5Nr/zp3J9f/8CaIo+7a2bTi+nsYjr5Npv480/+7MquyQudtJjZ7GKCn4Vd
+        MrnyJ1O7BAW4DnZ8whjjv2OEV45FdjQBW62T1vaX1tL//xlNbRkJRO1Rkp218+b4PXmSNTQnOCvm
+        aGM6k5ta7RiHcULzXJOYGcqFfuXG7U3zZxhfXh10L5EsMjyr6cjbUoP2G/1Be6npeDw/QwZDAtWB
+        qxCeb1SBMZW9kiv5xCKj9wdXe7GtTJ2VW77mB6vs/bR27sBab4/RVsqVkvW0ygmo6ykGT/WYLOaa
+        hoK1F2TOslpjcyM3SE0esUzj7muMHQ0FdjukbnMrXAeGpTmGdO0UzsicRxD49z8jb8M1D7ngZocn
+        kBchmHCqOyD7UNvZGaPE1p+Vc2O2pIUwgTuTAJBSbTDgs2fTNA9cVBm5ZhgzOI3dyczHHLCvbbWH
+        yHYc8jEHtGPdtyalH3PAehg/ZA6YMbNFDWnqDGpA95hV17H5y79Rz1PcXRgAAA==
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Cache-Control:
+      - public, max-age=60, s-maxage=60
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1300'
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 14 Feb 2022 16:46:24 GMT
+      ETag:
+      - W/"ab9acf6575626db34519b52a8c6979b079087f717e4fa86afe700ea3991782e4"
+      Last-Modified:
+      - Fri, 10 Dec 2021 20:35:26 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept, Accept-Encoding, Accept, X-Requested-With
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v3; format=json
+      X-GitHub-Request-Id:
+      - 9976:31C6:362E73:A59E7E:620A8760
+      X-RateLimit-Limit:
+      - '60'
+      X-RateLimit-Remaining:
+      - '52'
+      X-RateLimit-Reset:
+      - '1644860504'
+      X-RateLimit-Resource:
+      - core
+      X-RateLimit-Used:
+      - '8'
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://gnome.org/.well-known/org.flathub.VerifiedApps.txt
+  response:
+    body:
+      string: ''
+    headers:
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Mon, 14 Feb 2022 16:46:24 GMT
+      Location:
+      - https://www.gnome.org/
+      Server:
+      - nginx/1.18.0
+      Set-Cookie:
+      - 0235448947997ebd73869bdcdc930c7f=3d9110a53a3662714d7b7bec51134888; path=/;
+        HttpOnly; Secure; SameSite=None
+      Transfer-Encoding:
+      - chunked
+      X-Powered-By:
+      - PHP/7.4.27
+    status:
+      code: 302
+      message: Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - 0235448947997ebd73869bdcdc930c7f=3d9110a53a3662714d7b7bec51134888
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://www.gnome.org/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEA919+XLbRhPn33bVvgNMVSwpIcFL1EGJyjq2c1TlcEXOprbilAokQRI2SfADQB2f
+        oqp9iH2JfY19lH2S/XX3zGAAguIh2fXt5pAEYKanp6enp6enu+fsxZvfXr//7+/eOqNkMj5/fka/
+        nN7Yi+NOif4uOWNvOuyU/Gnlj4sSFfC9/vnzZ2cTP/Gc3siLYj/plP54/33lGJ+fnY2D6Scn8sed
+        0iwKB8HYLzmjyB8QtGQWt6vV4WQ2dMNoWL0ZTKv1OiqhVhIkY//8h19/++Wt83LnuFGvnzoXwWQ2
+        9stO1/fmSTCYj8uOP/aH3jRxz6pS4bmgMfUmfmc3CrthEu86vXCa+NOkszvxbirBxBv6lVnkXwX+
+        dXvsRUN/16miH4w/VyzRp1kYJSVTtXQd9JNRp49aPb/CD2UnmAZJ4I0rcc8b+x0gnvZ1tz+NqZGB
+        n/RGu9Lh3Wr1+vraHU7DiU/9lWYNeZZUGQD52B2G4XDse7MgdnvhZL2asXtd0EzJGyd+NPUSjENy
+        O/M7JW82Gwc9LwnCaTWK429uaJCZnJ2SGoDI+9c8PHW+9/1+fvQyXaoOUKJaYnrGvSiYJefPr4Np
+        P7x2L69n/iT8GFz4SRJMh7HTce5KXS/2/4jGpbZihg/VD1WF9ocqj1T8odoLI/9DlSt/qNabbt2t
+        fageNW6OGh+qpXLJv0lQ351Nh3iIr4bbwUNFhobfbwUg/iKA4Tzq+aX2XQlcBCIxGhl8MwT4UL2e
+        VYJpbzzv+0D9I/7HC65UwRzw0V93Ekzdj/G3V37Uabknpfv70+fVr18470dB7ND8cPAbDB5Whv7U
+        j9Bk3/m6+vzFYD7t0Rjt+WWvnOzfXXmRMy1H5bAcdDy3F/ko+XbsT8Dpe6WeN73y4tJ+edYJ3KGf
+        vKYpcJO8fGk/7ZUa/dL+qQbsxACtAHudiyTCMLmDKJy8xqR+Hfb905nbQxei3/1eslcr18qBKzMh
+        cEd+MBwlaM5FD8bv0dSe5xJj3e4l6FfZ30fx2v6pD3SS8I2XeH/8/vPe/mnkJ/No6mwPGG0S4LLf
+        6WRB35tu9fZ8oVaySCdhUhAhceOo10H/3T4mbdRJXJkcRLXqRw/EZHYulT0ip6Jz/N3te2/4K4TN
+        XonEYGn/r9rf1G1/2n89Csb9vWT/fhBGe2HnVRR5t3ulwdgjrhIu2kdr8XxGkibu3PlgiFsQazps
+        v6iV06e3Nz1/lnyPinh/X446tdPoLHTH/nSYjE6jb77ZT6H8Ff4V/f13R3edOh4M9l7M/vnnRToy
+        +0L0F/XT+DqAeNqbudTL78CbEEYQCEk4K9FIgmc6pcNazWk2ZjfOqwiyroSRvOuhpPSkrcYv3vur
+        3jg6OT4qH7ZqzZPycaPWKp8cn7Tk+e/ywuem/Xn/2xf19gsAabWarcNy6/C4gZ/67/oJ6psnfAH0
+        Zubz/suXVu2jZrMBGPXGMX4eNFBU/12nN/p9Pf27WUv/tssfHKUtM1Rp2YBoKlT0C8DPlajnXqCl
+        XIk8DLS5f8oUVqJGjRaRuFY7PrApTEQ5AuqH9SaROPtZSKQ/79/rUb/fIyaxec9NmQ18rznSevvy
+        ZfpaWKws4/+i0yFgL1/upQWseinrFsNNvy+2wFNSTY4tQb6wkKKJh+n25rdffsdEve28qOMJMrN/
+        +9obj7te71M6a/bv7IKYcxaclFT//LM3zdbJgNvbv4es8Pr9t1eQyD8HMVQQP/qWxGLu3V4JWLGA
+        RrnQ62ONLU/LL+oQagVlxyihvu+391AiSbzeiBvZK4VT9Xmf2s5+YeziBKsElLTp0C+VjZjYp9WN
+        dCsoBZCjnhDmgsrSwOT7tb9fRtdBFF4b//nn7n4fWolZHb/t7U3t5/321FWL/8uXUze5ZsYGz1A5
+        9bRfpgdVan9//35P1IZyP+zNaUkrL1Ej9k+fn1W1qnEWJ7fQGp8HkyFgVeIJVtPbMj9ym87d82f9
+        IJ6Nvds2tDeSds4LKJUQwFAiT58/64ZR34/azjRc/HJTiUceNJmir7L8tZ26P8kC5PWx4P0Eemcw
+        bTs1p+bWjvK1sBIk0MjGFW8cDFGqUnMXIBPLDqNwPu0XITQDk9FKggbsDt4TsYRGlmK+y6/ike8n
+        u07Q7+yCdt1x2PtUGQfdyItuK70YarTSYrXantF7bLWnitJVkDmpZoBIw6z9oIBWf3adid8PvM4u
+        ZqGotYxMMRrJCOoN1CsaOMbp/DmNszTjzftBCAVq2PNmpCfd9cJxGLV3Wq3WKS1llTj4t9+uN2c3
+        p7TcKdr2wFt+dO8GcaXvRZ8q3ISzEuooHnukAn1VhtT9quwetvbv00o9KEvn9OOOGx54YMTb9i8+
+        ZmcZEz0OsZ0qT8Kp1wvpVxjPvJ5/qvCt+/TvqR5B9xjcgdE/VbxZx1IMAEHf2en3++ptJfL6wTxu
+        H8xuLDT8SRe641NTZAnUQorwyMSVIQYXyk3lKUbmQZCFSBgO4Q3Fk9NjCdSHUZnNx2NsqRL/Toa1
+        Ap2LRk+GVo8qtq9JOLHei9ioqPd196gFxhC+6c2jCLz8mpje4gHT0OVlL4BAx8Qop4xqvjr46Bd+
+        GITAMlKTyW5EZlESedMYKu6kjbXaj0hxsWabe1xvEIoy/0jwtKco640tDDNkGPuDpO1SHUUJJSgh
+        Jx3VXTUxKlwUEyMPKt8Vhu8s70YqGzS2szDGxj6cQrsdg2JXukcP4O+OvLiSipVKRNshPbaMKS0p
+        elz5a6abmU7V9OQXMO2CTubbEzGmGgSN0VYWZJ5KJPDY+GENOlOKPrAIXvUZq2gwtVu0moixS+yN
+        LDEqLy4vx17XH4tUvOYtY/uoVrMq0oo2a1+P/Mjf4z6my9z+nRaJdWGQhtsk/rdqx/7Mw4Y5jGy0
+        NNHVpKGtDMvPUzWZeHRov61fyOjwmxCCOUhu2+5BUSugc7KX0gtrvQ9dJ/OuDwPU/p1oAVgpMuLZ
+        YJvraCEIJSZUJ3iAldKBBaEIuYeBLsdVQQWZLKiJ14VdAmuj11ek1TIIy6mQc7E0TTldmsTbA0X7
+        FhfqtsxwuyRB8qvf6TVUtUoXqukn0CsnUgTEUy98S6A+LOivwBRPr5UsgfowKrBdYc4mMH56UZJj
+        D0Ps7NzSU4KGr6YfFA/WLGVSFG9W2objsEs2URKWcVZX64b927tKBesxmUZhJq5UeO2qQIODNtt2
+        dmr8z2lhmd6tN0XBeRCPKkMYU1Dc63aPe83i4tcjrGgoM+B/isvMYLetzGCfpnJHx33vqLjcVQCC
+        w34HVXunN2j4Db+43HgO2144jytSIcTaOBQcDk9qtbXqeNDZsAHZGfS6y6vQ4gIa+LDBE1VQ/Kjb
+        73VbxS0IMpnitVofpoTi4kwUTWzC/tjv1we94sIC2y5dOzxp+kvGRErP5hG2mgB80m3V/TxZMLT9
+        AIpMRRHRwIaKpF5pALQN8CJiBq6xV2+2+v6wHA273t5huX5wVG40jsr1fQcaOl7u1Vut8nEdLw/2
+        HVLb93N90oAq2PdkKZy2bZNxeft79UYD7dTK9eOaab5WbtSOy/Um3qxoPctGzBKEwRL2Wo6Gt9do
+        NYBDCzZSQwZ62cK2Rb3cCBXh6JQaPCUebt9qSg1Do3ZUPjjEf6voQAZRMxTeLTWruSEVAstb32s0
+        j8vqfzMI9cMTEOSgXD9prWq+F4ZjavPaiyaVeAajdzSftJ0HGjw6QHv4v5EOer1VL9fBCI3ayb7T
+        sClAAwMSHOh3QPYAeBF7HOp3VJktqfvOsXmHBg6Oy0cryQdZCVEprLx6yjBXNGqH6AEgq8bqxD4t
+        YH+wkmmlNV6mvfnNg2RqtNAFdKuOXbNuid4dtPDfvtPSjYNPauXDxqpxMtOiP48hyR8YH2J8sh3X
+        6wCqWzmBuRpkPsEr3fIh5ARYp3a8qmmWlWHPJxm8ql30Dm2n7R6ThICIIlx0wzTehxBZx5itD09M
+        nCWBH4MeSb84frj1GloCx8DwnbZebwIbCMnGSjaaBP0picOH2yiDqg2wuKLqAQROHbzUWjJ6fex9
+        sUmpiNEFfbjlQ9S2M4/Ge7s7UBF0CbbKmAK7eZmti7FKsAzGGtVlglRu/fGYTHwLaGS+L8cCs8AX
+        RWEBgv60vHJK6YXK+tMDlXGsPU285T2gc++0wHJAqqe80C0nBH9eDoQ7q/Wfhd5YXxdAmO14BfZb
+        2I1gPCWTXVYltAqR+ZDEcgObq+WleKvbdpqHDxW6kS1v2znA7uf0XlRk0kxFTVU2EAcHr3tZdGwt
+        dt82uAqM/KK1Jrh8tQLIrOSuCY7LFsAwSvCacEz5Alii4EErWBOWKV8Ay4h1KaRUDyb1ypEorLu6
+        DdG0tmqCqxa1kNck14Seq1YAWciS6qMbkTytVgA5uwNYE262UgFUwVczNez3ZKlcOZK5WkvhKqm1
+        CVCpUgCRd6OV1PKkUM2/aD+BJMjDvMu/eKARTUqtCxf0RORDHuYmjayWGo+Bvp4seUwLwj+QSAXU
+        KZQSjxr3QoirWxa585hu5hpeWxo9qs0tZNRj2ssLvAK6ZoXQo4YyC6qgrZxkelRjOVhLW1NS7vFU
+        XCX7+Bxcyz3r4QFxxFKzAPO8mILlmA7ZNwOeB1LQjpJ1WwBfQ8ZtAXVN2bYF5C1k2hat5ESK6F8F
+        dM+VU7Ls8Q2uL8O2aWsb2bVFO1vIrC1a2VxWbdHIpjJq6yaWyqYcBqkZUolFbPPFdJzKR0vVKRJd
+        psYqY3MR3+dYKEUnVa6NbdpaHdZGaR0jdBFem1iPH4fgJi2txrTAuPyU6BWAL8BpDZvzo5BaA34B
+        VoWm6EfhUQixoGWYanJG5Ec1uwhuaZvalPwE7WlQBW2Z1YuMx49qKgOpoCUW0mwrflQzKZiCNrJW
+        4Ue1kwVV0JY2ST6qFQ2kAD5b/yrG0idOI+zDV7DvNsWU1bAAnhgKtwAoFQsgslFxC4BcrwCesj9u
+        AVHVzMJMfT2tuCQ5l09dPZlw3rUfIyhpPTdPePpSNFWVPSXjKnP09ayKUwg/iasET34qoOwNCjtu
+        zvGz3nLri76fOEORWLEFl9SYY79wmoVDgwAoxE+BLDmqIuIi6lcXwGfQbbgHbm0TbBVRlCPVWt6z
+        D5OVMOWhy+BFsVCNTfCi0XmKwUaEU7U3j+GcCJ/aSI89IWm3sDjqx5uhq8ko0W9qXrDTeSWG2yG8
+        SHAibLkmV4X9ctFyxIHfig9u54Jrf3OB2t+8i8Kvmq/omK3xusE/m/zzgH+2+CeiX/AVPmr4ecw/
+        4ZWBv1ErkGr0C/XoFyrSL9SkX6hKv1CXfqEy/ULt4OVOrXl8Gs+7FChJDoZTeaM80zvxtTeTN1AW
+        KERscYTF4d2hkKXdpf7YD3PUx7iKwIR+GIGxJvDUGgFmqKapik5T7EUe4eE1TmPSUpWP8e657XfP
+        wVEr8NFhcYiKq3781xyH++oX87Rp85CmGrUpZWAniPynba8yCaD4J5lIvKbbJN602lWF8k0bEVV6
+        2w+SP37/qTiMsp8Jo/z94s3DcZOIuYxmPXc2mn0bxYixpIDUtKXr8fXEmwYDP0ZI6mLQpvVZWs3G
+        1y531Lcquhz1WT13MoGwKgIxjKxI2D+xsXsH963YoejFHKaIOwynFLrwcHdz1XbjEUIwqL86VLaY
+        qXNxrw+Hsn6Mw+k3IXurP4wMDpupbFXKVhFeimBTeM5/i3PLDiMCMfFV43v8lyElnnP9WESIwwdB
+        2s+NiMgL8sP2ko4ayudnLyoV5xf4w05Cp1I5/y/Pz5TcKA5tRAGHVCvncub9C+G5OuJm8emff5y/
+        /j6l4tWvHXiA9z75EeI4klHYj+EH8cl3SpBtr3mBeBMgfCeGN3XJwSjPx32EbztgkDFCE7o+MEZh
+        BvEO59P/DYHXJUS7EmjCwp1h97H3126mwC4C5PIF/Cl5qP4MDnpP6CD0RZfaS6OcnDuqJn2cd0oI
+        x/a7FBCF8Godk10tMehs6+gLQ/WjP6LxbtmZf4NIcqIqzVfdzkKVC/gf/tRH8d16WobI2++YoCZn
+        2OnnQnd3ZYx298tOjI+FwaamDMJNFb5DiVfdZYZL41V3T52h68W3014H3ks+PdGikfYAgvzUiV24
+        hEKn+xUhK24wjRF+9B0Pzd6wHAux7/cRrQsO0rFW+BNxKxLifTY7P0PIFYv/Yqqm5Po26MO5HtHy
+        L73JDOG/PcTNO6zZdEpiGIajaclBkHqnRLPrrArgVdMUmiWmfjvta8amwGTibktckn64csrr1XE+
+        o5C5uNqoNWrV2nEVqyACGfqsZFaajZtmw/04GwJHaDpIgcBv8tP+6RqEG9IN/s80qd7lG6Xoah9G
+        p3lvxMg+TY/hsHiD/wWBXFqESUxtqlQBlfcIrvuJnEqstaFYbEPArkXtxlHtBv+btp89S/2KSwSE
+        BQppfJRY4tkzcC1SOZBTOo4TOGGBtUkkHw7LJ707RyjN1PHuOEij70Or4GAYOI9nQv0KqrRHIRQx
+        dVK945/Qv/euQgYxCRyJoh2oJSyFnFHugb4JtnvGbPsbeYr9+c55fXFBLAt5TF7SakXnmSt9sztm
+        mQvlyKStXJrvIXt/4AwBYwb4ddUTTBH6yaZD9eRK1ByRCWLR4VjvdltEb7n4ozdAyE95B17fsFvS
+        SQ3v+Jxz3YD5Eoc9BIVD5LtaVfcnXjB2TEGa65WpdxUMmdqV68ibOW4fcwyRlNMKloa5cz4OLNBc
+        Q8bUVVt2eXJ21KPEktBa58io6o5qHCZhF7zJwHlmGHRcBI8NKxB00a2LIJ/EsV4oPnJc/izstF5F
+        Co+d0Dqme21BBX3nk+4UNJFmMy1SOolhGN06XnmO/THlTwEpDBSiEiLmym6McQObgIyMtUVPx8VL
+        2hR/ijGwlDKlTE72DkJ2ydO/X6Fe5vrCBcjDDoswNgBYkFRYnqpKo+31ErjuD+D7GvSxAlFOBG8+
+        TpzggTLdYCg787SUzFdGT0FyDKOo+SO4W90W/O2v61bVPC0QqOcIydLkjzWUhaaEh9PPBsMsK1Pe
+        FbAr4kbn0HMixzzzuJmnyEfOCx6R8g6U5FmIlWoHWnHPH2MeCYS0jOLcHYlOUzhgKNVzN7wx7KDL
+        SPTFstfZUjK/DEPFQT8yFcFVfUxtSuxTMfMxCYfgND2frBI0USuYy5MKBbr1KLcFFAYXfILwOMxe
+        YlIDblVh59wunWu8HExn8+QvVlF7I7/3CUT4u81/If5CxJaWxQfe8WFvcL/RBAEHgvdpxXbmMUIe
+        HxIJ+Zmdq6tY9YH5km1refl07mRq3MVJFH7y2zuqoxZpSiL6Sn/b9CpxVE3uHQwNkyDBS6khlC2Z
+        t668Lu+sKardbjLFgDvnCFpGKKmZYMI0mPsioziWUK8cZTecXFcmYR9rBf/ZG4cxBDS9WEuijAMD
+        nonYD64QxEpLAJiR6A+zYFRBRijA1+95gbAoJj0GGUhArg3AJtp2EAxCrK0IvIJFXfNynqBYy6ef
+        RI4jIxEz7vLa63CYoaVhteXwKL8P5L9SrmzHDcOTHI+dieFlHzzzfSddro2c0VGB2ZI5tQCJSLos
+        wJaUtiauGOJ54c4ssPn5uwSS1hum/nWMHBjQfWBqRMwHKysWByFtDxby0t/tAZJSxEuArbecFFde
+        e8Uorr7R6AfFMPQCIgOPpegpiZPyihXvmeEdCsbFjObEDWpGbNQri6ct/wPDjPZgykzEaLJ6XyRG
+        C75osak+2dLBiNSCaqYt5pzCtha/mLbkU3Fb8k0JcdXyhqJcammBzhqjSG/RdB4S3poMG4lUaxCU
+        RN0KjE2Px8Apks+C0HK5SDxpf5VUO6QetgfBjd+/VzpXTlFRb7NqRH6Rd1VcuI9ohNtwjk2K2n9V
+        YKMhRUuC3PVn85WnDrQwH1u2fB0NAcrjCHlQuEzsxj0V6p8vvqyJXPW4JwdcuepEnBRLEtPpk+rS
+        jhHegR8751/zopyWKqxjJBHW0QD5CymTxRpN2QreMEIY7+IyEUyhPegNfJv37ikugrGhMukYpKcn
+        yG6gqUrjkqluhYBAOc2OFxQUWVOplkOKMA0YnCJvMiDu/yvtdj0HGZ1uHdjZEOvreNhL7CHCWNpv
+        nxzCyrB/l0GjbJ6Ws4NKR3Dc+Op+g1YsrJc1YhXRKQ+O0cYOVs0pNkFiReBVdYGLsblfKKTpARsX
+        RZ/rfBYq/FyGybIAlTleB5biKTRTsmaaHb1VSMNs11tIXFBz+Oe9bW9x7AdRfKDSpoYmN3Uu07lE
+        048FlXMiAAMOi0iXNJMewkm7SPWopN8KwMvqrQs/K3Sw74GZXPJHFXVjWWtZKHnRtQNGxRkiDZhl
+        iWtQViLrUwpDcQkVONV5J6iwLPlitxIxL1q7tXKY1Va+2ItB4Scppjc73MDaewCrWbXQCLS1AdjY
+        bQehaJGyF6Ailcmmn73CWt0xpLK/29g+UMCuktU/HktdG/LaNLZ6pbUBsU48fqy2wsem4qMQKhr6
+        rTAqBCQ0Ws5KMDJ/hxVcWZiVpYW3o2aloazKsiLuiHnXbGG16XJFedhjsOIjzFJoFm9aDdZ5suSI
+        mXRFW7z6q5VhvSrKNLteYWU9VmudY4y3a2Gla43qWzU2amxXrbldtYPtqrW2q3a4ZjXDS5yWbdNK
+        KlHdptU4Hc+mlXiPtWklPr2CsJ9PputOE+F4zVtImr7JRNHVwnWrGfr36NCMU6Kt2aAcVXjDdful
+        rOmx3hbxIcmKeWawYwePspJX5q1S1cMom9RLEnLRATCbGPfvjMRr12us3axHUtMO86bLyT1JTV+T
+        QEXVJc9cik+rzseea4nCIniEDrpHyUnlJBOHRL09yk/hVBwGjjyXW0PX2DJ4SbP2ePgylBsixUtG
+        pqPFGeDokPVHPmBWK6DYVrAihk76J87KsIOEoYTOd0FWZQOkcxDs8PiMlC2ZqpxUVGectKG8lA2e
+        2bDwAQrtChVcPo9VX7VN3XGL3kqNO6VMHx6z5r32GWzag8Uj1LJrv2MDfvkBFHBEcAfLNR3PU5xM
+        20JFOr58u8YJCIPep1tFYbv81ahi7fAcmacLZV0MryTQVXVtI7S8QpIOJEPrIf9mug/KKtH2KOVs
+        pZJTDHsaoqzA482nAi07d5cEIKwHetz47WJznK2KkunjXxdZZFOuWmAwx3PgZqNOalSzkvhRtaFq
+        LJy3w8u+jwNxRpdZlwFZYqzRIocFuz9W49afwl6fAw/FJvUjQsT1BwOkt6mQa4YgtdAlc2rIk0xc
+        CHCEjlNKOi8RY2Zb/Bg0tARukU8Jb0BHn49BT/tgqN4+Gl62u1PMvqdE79HwGL3FCaDdWfQwDeCi
+        /ZR4PxpelqwxMsDDmsVzaUOulF1bIW9uBtWNBz+SdIGQLeZ5bRRSgkqTdrNWMtC/IO6s46pc63WI
+        A5jpFI+UK9lnJbHWGoYH17bl6wM8JHBUnaPnBqOfGrvE3UCrCPZiys4IsAVnHBNWoZQtbixxmaVp
+        LcIoW4JRXhYxUyVWYSTFNKmQNbI1GGwyQorFsmRYiVaWDlgcOfUwn99mV3oZyaJGDPE2whkegBGb
+        mXnVId8YTJg13Siydck7CLE0NJ23qq/aNsO0jr63FIPsKG7ETlmY/79RZFFRPDw6Oer590v9Fibm
+        qAbhRaTWZJUW4+CQYVpdBocsir/gNg+HJfBX6qiV00eP+J97D5sg44Qlrlx02EdeXiTDFjswaNC/
+        NEfhGDYOiPnwB0wEO0oIaGTwjr8XvsbHHD4+7jDBIaiY8Rmmp+zvCp0Cp7MlbcI3shgZKKEpPaWz
+        piTtqdSZGSNuAbE+GdFi7dBAQboHRe3gpNtwGs7tDBQZLFi4gItojDNB9mwiia42bxr7dQq3RWMt
+        GKmML4RQVE33lMgPOvOtKgafw4IxMqJtmdvfAthVNR72/dPEyvKdOSJb9nmBE7QozPOraEs0l5Z1
+        aKGJlVXQI40uDr7If/IBPswhZjHF+tyYldD1Q++E1tmlPCnFN+LMZVWW86fCAtaS7/m+COdPPuSO
+        tdUk6+BawOD1Lv17n3M/KueeYVDPv2F/XrWTyn/jI4qcL7NDfouG2GTfpALiO71QH/EpdJAsvsR9
+        eFQvNA9Pa6uItkkuFlNn45nSJCUoXormnhYxesHNEoyFb+5VoQt3vgeZQsloAa/sd5rNC0UKiYi1
+        IoeOIem6XnSLEJa7bC+WzbvZQUhn3ROLGUqcNvIsYVTONWGorhe5Z8s4m1N9PaxKfqfz4zu+2iU3
+        PcS1wfgokIsDNj/yy0wNKZTKRIMM3RWDnRLPP3U9Q8YBfBGXC+UtRPEoX1e1Y4pE0mSpqb1TFRtL
+        EWUnVg4Z5FFB5tL3t7MQ4bWz0a3qHXGVuAOoi5AkCNuhIGwHQdinnIOAQ2HUVQ7qDd/XRBlb9fJ7
+        coB/T22zYt1t5e+hoYCeexyh4Ths1CyPDsqjVnmE46NMGAz8Dy3P1nRvWDRNRTZgGkywuCVsOEQu
+        cg62sINFyIpvfHmMl49QintY3HugavlKcIJa3V3xbh815Lu6LwXR5RZ52HUiUz5HnuP7UTNjiEXG
+        gPvRwcKrDba0ao+iDJC0hOXt14NUUxUOFPtctiJFFwmMTawpWRhrWT/N6ky6iYo2yoJRgUVbYGOk
+        nlp+Rf2BXIc8emDQZQTViCJtgDWiddjsT5UXMt0LhmOtNl/xku2G0mtT80+2R2uNCk624ZkgI0TL
+        6GqMOf1KHVOSDoEeZHYpCZGQ48dWXo7BL2x2KwdDIgd41pMXkMlfclalkcG10GesburLqJGxxGHH
+        LKhzcrGJDlOit/IJ/n64B6JRd3Aqo2OK6OwGj3xuhNlMMToxmXK1aYYFBeI9pX8ysI4CLTfOzMJg
+        mui7oflMUDlAkDpBMsIcyDkULsMuoXApp4u0Sg7v5NBpXLRq/pS3EpatYyhjxLxMPLrBufqn332H
+        LtHN2M+f0b9ncIuhXAUl+IfilJXcLhCFKZd0k2USf0d8j/azM9zJrd5/CmZiHFenTeSDpo5odewo
+        e+GVzi9Q1ElC3cOzqkd3cqPdtOFMk6Y1KvJMrgSHdZIQtI5IDIbYF+MEdKxnP9V2oFx5eEFnRbhz
+        9ng7Mr37kbtUcuCFBvJ2PTqWYzoQXtyBtAcWZrJVM/gBIe46R5UIGaXuM7CgpjxXp8MUu5qFNo/z
+        0hH9Dm6KSPNAZLVG08BcRMiM5kO5HVJUVOQd0OMhB0XoAvYRpgxiq3GRLyYDG69wKTszFsdvY/HD
+        HeclXPgAftBD0ULoMyLGzW3tmRQIdO2j4vnqskBqohHfzq0Z0ZqHKtD7B7rmnduhlCiPb8qp35Rx
+        f71cL782woRoBZFYhKzTuJHoc3A+wngx6OccwSvLJJfks1kO4+U5WVhIfbbmDQ9xzi5rhm0akuuk
+        SpCq5rBiW55Y+PsMddOJlQJKYZhgW4dcau1gUZ5oRuasL34uUOdXA1bdfa0nmY0CSwngiMWJ5j4v
+        hoSEQY4x4mU4u5rFA16FShTFn1YlVEl8nxylAHQcItJN6IhEmmS8Rbukv6wPYfcjnSLyapAWF4Dn
+        EIwPTSW6JXeKOJQhHNRxob2SoQyFDhiBKe0j9Xs+smCReP7eqoj4bxRC/gIP/4+Dwt6dNDDDbPDU
+        a6sTG/eOAK7qndfFwlGZb9azV1TJ+SNeq1e1xhP3CgBX9Yoi1YLpVTi+8vsbjdkPfuL8pCqu0bvD
+        4yaSVqwaMxFz1kgqdlx4X2d41LkEjjckAC+RSxk8lmNQHGQiXJviHux8JRk8HmZNFrMw0Ggwa3QV
+        t56vMfkWurSsq3bwsKNFgEWiOre3OM505ppN07JBt/lu7Pgs0FUgseAzFoXXzsDDfxVc0gaLL+Uj
+        UGvjCO4S/rSDtDRzLJeiS8DxAvxXxRxO5/RzEnRau1KKNNZpulk5L8SOmgdYVJ+OZRjeGnRiwlVP
+        NpsNf7x68/a11U+WXUt6tcY0X5s7MPoHRbN8YfRVrw426xYpGc6rOPDW7FrziQesWSDAFrqmc0JU
+        j7bp3AA3Qi1076w6HyPXyNIF6GmF2cEJ4K0WZnSolYqxLKUflmIXqJkfwYIZd1g/RnayVTOOTI5r
+        qg0McHHKZdXLPi71TvyNhu4NVynqkRYtfKKtzhagzmPbYJSXNNNT+yoM+nu1fdNn1jTlNFzVddST
+        FrzqtZJ6fDVvp3QhV/dSaixoIhhJIzcdPtVCxh9kogtoJ8sbiRXCUms+woNm85Qe0mtkDN5ihalY
+        5/gcVcDKK4Tr8zMO7BepLIVKWEEo91inhNXTwEkBAFPkqQgh0Yv3BCKz6WZiXBMdYVNNbpwKAYkE
+        B0fT5tdW+Qo20eeKdkgpGjuKgGpcqTZHqKhkPxpx3sMXNKcZF4QeY59IzqmwP+JkEqmzSuFgUHLY
+        e3EUjrGF14NWQoqYCb6r9EiY8dQn3sAQzUgGWBuZxSFIdytVrJH2hidV8k0ZvSFBx2yo4BlryyEh
+        9JTqSLYxtFPiv9SmV3G4trwsGNFoJ65esolIdsGAIf+tMw0smCVHWFZx+i+cJsj5BRsJHl7CDKNk
+        SM/KAbxw4yJOZ12AO0MEMPYRxssmSFHXQE2K0SWygCAExK7B81ZNAnuPKSYIKs2NYCKwWcyP7IGS
+        egJaFX12xqGVvCGz92LcDn/iqaX0HN6uqX0crB0Knhon2kkpqw2PRHYUyRCABmD4oWGzyiprBkPl
+        3o7qmsh2KTaVU12xoiC56wwzFhYdMviXzll7RZ/rgp0igk06O0xT2tQ0zhPLLqmJpTpDdNJmvKyR
+        y+6eYURjD5pFsGlFt0b8aBgc5kudMminJihVxtThIVEvmRB6IIgzn5/h2uagh0RQel1QEQ80KOkn
+        Ze9ivFRB6M5IMpUjLG1Z1SCKUUsl4VOOuHToVMT3unEYfiRmi2zUZGQTFoaBEgI6GM6RDku1bkpy
+        1AMy+wXDKSxNPmfUY+MpLTJIH6jNT8cNKJXa/nRyhIeNDVD1aq1ZvYY5J4aYRP76g5pYoDitoGyD
+        LH0cGDJulfrhyRHUdDS3sR2quEWnjs5cb2aLWoRUQX7hm/oh98HB348HSGErN62DQzZ10cPjQR4d
+        Ht8c1AVH/P14gPVW8/DmuH4iOOIBmUFVEsY9Y1/H7ZCgMMLg6brUKzQqj2K7Ez7EHFJm26fj8FSA
+        0Y6WrT/M1xU5kIKwgkUBasB0GDtQCX3wNhIG+B7CFGFZnmA1Tsoczk+THaqMq+QaEJ3pebME8qsp
+        wUHOOCQDQI7+oYeTiGvvlsz1yGflIGMEGa8nyKGFiBRH8XrdgUbS92NMPaRdRdGRP55RWZxP4OQD
+        Jx7IxYp8eFCH4wCJVBUE4O/4NzM/woXcPd91KBnn56AmrRhwCetQkkclVSRpAnwiDRn4lJMfU0c2
+        dEvlWCeJAv6gfIpk+Dex7epstOH3Gke+PkiWpxLSWz49a5CKm+8Nh34wm1jij1EHosjSB2cxUVNM
+        DzhThTnXQico4K99UP+KVUEIzCUyNm3p8pL/VrKVcpxiNDulsfdvrFFa1J7UsUfSorZeO8LTdrKW
+        vNGvkLy3QMw6+ptZ5mx5e1i31oHtJa9uQ4QFurWN/NFAlLwVybOlvDWwRNQePU7UGmgsZZGSlo4o
+        tpSyBpYI2MODVQIW1LQFLD9mBKyta5gZbHOi1nOwAxk1zi/YxZIF2FuSZBBHf8Q+JGBD5uPs/C24
+        6RYaZJQ44SCVYRAFEFOIvrAl2cRDuukgARfR9kjEooIKeeg67yHbXlGawiChXDO/KUYlgejpSkp+
+        ej34YeM1ssixGO16cdCDUTb+FLvOK2fGSc+BkKfyjjIMFEbrCbCIqSc0CaQ2TninKod2XHbG3nza
+        GzlWAl28hHjjxIZOMEiFMfynsJ+NY6h1aPZHnLuQFCaK8ILiIJcKrSigKYyiEMyQ2hTIhjrkT0My
+        HSvOy53jRv3oNFHyPXTG2O5NBTHqrReRFRg9mXj/xsn3AAnxEHJF7uyOffKBdQkSX+1OeJvHEnP0
+        BAK7HybYWG0tsNcSsbR2CB9CwmKRq/AmUhaNzSQvbcAdiN8nk7zQuVLJ2zo63FbwDtgCECMwhjQ6
+        ETPQ2yl9ttZzYdQgKwGonRLN6LuHh08if4vQgEq2nWKpgYna+ygxrEE9gdzUoBbF5hb6vQKmlqtG
+        bYluCwLaopcfHyN6f5omc8hBqHykPr4dDIIeSRBb9hqNEftvymtAYpKTzEFxvA4jSq3v+NOrIAqn
+        OA0lLdeDlIE6KbIHFjhb8XWdn5A1OIYsJ0VH1OCB7yXYH0JcUtXrABKUhTiJLs6jjJb7c84s20bj
+        s/Daj+DPpKyXjqqebzgvvAlXZxDBJZKkJYtIJLpHhyrdW06BpmWzANLLCOvWWo5TvFyEnKU6Xz9o
+        Qb3D1hV2NifBzQYA6XuTMS0bcAny6VoRGBqln0jdRSGYQAyyNoFFcBTQCjAeh9dCKzSTx5rcYLSE
+        VzjTSEFO84pAxI9vYzohZuKpvQTuPkBKU98boxHaaEzDBCZaHCUAF1p7kNOSahKB/zVHtDRKi99T
+        n9qS5QNrUeRjXKa0iqGPE/oE56F0maH+/j++IPwn6NyYxE8i+TOD/KD8z5QsXAVax0+yCmQayqC0
+        9VqQBfkEK0IW4BOsC1mAanVopUr1FqtDBqRaI+pHX2iN+B5CCwLidURxz317aRC13Itn8KopVsx7
+        UolEyIC04hDLwQgGYSjucLfxogkuBwrnJArhoFeGRk1LDIkmFjRxAMmGJYUknpamWDRsC8RvsG4g
+        2SZKkZhFM31kzceFA6L8QqHnS6oYwiwcB/EI9dVyIhITslArySzJlZGGROM1m1IgP8nNBYizzIQQ
+        JIEPndnVG5EaLWgxhGs8uCXcgQVZXgjrrg9FMaDFCi+7Ph3PLJGYZCZ4OntU1uhA2y02xFcOGzXv
+        +Oiw3u16gy45vYp1hfL+zVJTBJTaLACr1OUln0GkWbZRWM57nnY78B9jvxk1tJpsLE9Z094rjPME
+        l66U+SdrLLTbatZO07mSJWfRePiHtXQ8VN4z2phQWXB35SM8OM0absyKYqlP1XgZKKmuNqUV3FqF
+        MTJuv2bQpdTlJZ2u58xoWI8if4AbkRTXV/g+pHR3JqmU6Xbledwm//RFA1vdaw26B2L4ZBVSnN5A
+        CL1/fLKd4yNYZeXgivZ7MZ/NYKLFnikd0lV2WalJkkFVhjS4dcgay5eokdSb+glrpdhu60JR/H/+
+        x/+Egop4EmiU2LjjPj5c/EQu6fzX92R6xaVa2gxShmAcRB7uBYCCTIcsKSAxKFODr/pXAarfOt+F
+        XqQEkDKBa94eD28uyYv1Mh5DJY4uYZe4pNMu2HodfKuwh6t8q1zPsgLCfNcV6GYScsDEzgL77Ctc
+        r9evcFJth39WlO88jl8zgia8xpUYZIiIcfBugOo3KM0+4bTzhoZ6SwSCYO6UEACDM5rsRyxJPs7t
+        EGZtPklwEryZzZtxSAeK4tSVrV78lpGfeUAv+50sF9k35LLJOeiBnUaN3mH39KlTgronzdGrhO4p
+        Qy/gXJS+FOMv8NcvQVAFz0YXbwVi7qWGmXutoarXGdoTKprmHFtOTiWW1DLDQQVthxPbg0JviyzH
+        RIpWwBWFWT9GOd5TUiuFTDeGcUwCm6S3sztjbS7AAtZRI7yso6ImZTk6pRfqkNORN6C6WEzeY6V/
+        g9z+vLFN/STRIYr26pSWfqd7ysjThcSd+mkR80mI3etPj44oCO1L0bdRrdWrr9/8ila3pSfXNtRT
+        T1+AVjFZfr8gqfjIlhplubk1uS7+uEAUhOI1efjMxBrgvG8EFziKMvpy07ZV/f63i4sfqd1tOUsD
+        MOT6XvVER2181rnI1qzki3OYanZbmr0jGxz84xSD6cfPzGLkH9kPhkHiIcUvjii+ONUyjW9LuzfS
+        g9+oB4aC2ZefmY7mZt0vTsC05W2p9zq9FVgxn/XmM9ON+K+HO0Jpo/8Jf7nzT19qBeVlwbRd8euH
+        9YOTk+ZB/aB58IhFVXfG8CFdgcrd++zCL54PPeS07MYclgoEvpiiZ1pOydisHx3y4dBWup4BaMho
+        vfkCPBn5fRx/8GT2SaR8MUqqhredy7/Dovajly4j5vkz08y7jl0Pp9WIfiLN7hrEq5C9ZBzO+7Ca
+        kMMTjHFfkpCE0bZUfPXnheE7/vtzU49i99xhGCLUqfrtYIj7l3dqzePTeTK5jGEz6Pkd+Vj54yL9
+        Qmfn80kHtiE/wjlY+qGHy5s9OJN1RjqHw5ckvGC6Ne1/YCoY8uvHzzwCrAf53YCSD33hTTISGVCz
+        2/LqG65u6KUfPzO9YPaiY9Uw5ulOketfdNlWzW9NtLeCvqGaef7MZAvjeRiPvziLUZvb8tdvFz87
+        v5GzlMoL9LPXNWTDt0Klxra0pAcRls0FZu8Cs3uvcdL8zzO72zY1trzz8MEYLKFk2kdqAyv8z+zt
+        9QsupU7tUsqNi0JOZHMMk3BVxQ3A8Y5DDPBDbZxfVCrmyi4VRcGBJ/ZnFfKgPyOAQobFrptGAHGo
+        y1mVAkxUxAoHn6goGAS1UEQHgrsoSwqHz8qf5ryagyP0OzKpxRsmUXn3vcrAIrFj6qSFrrm2g1ko
+        /kNaWZaEQ5nSrYI4kcDJSepgpYN+KMZYh35kY2VUC6qiClYxDKtiRTAYFkerKpR0jOLQLuuX4eDy
+        AA4aiEEOxxUJUVNVCDf2Sk9zC2RahJsIYXxJZQRDGnmrMfogZWD75/BRSl9A1xFPh2n0YTHjls7J
+        TvoDh9u+i0LKwSBcqKtTJOpzhGwuArIsyelEYLIgjwOlKzh/TWebOH6mNAQqtrAYVDYukxMeoHqa
+        w2CDyqAURkjnFWDf/jRbwAZwZEYjvY6cEAmJVnQjGydbxf2NSNkDx88+jofQH0SvRb0Rjp4D8qDd
+        AJeU0oCSjldq9F4FLfgUpPG71bRelXajvw0wTuTDRQOGUB8cX6kXq8Bit56OPATMlde7BYbv5C+r
+        tgpqBs9yaCZLnqz40reo0/EazRqRNCTnsry+YmIhIp2FYxq2xTMLHpvqRONRMytNFCBgDFRKNYKW
+        CyKbawefLSUDNSrXvNepFTPjf/dlk0C5P5QM0JM47QDJZDj9tFLKGHDwz9CAOZ/J+ikBCNyinCB/
+        Q4tPSuf61IZd3iwuWczEUGs9JfXQXSLTQi6Z7Owonf+JFyvQSkW1IdZjyFaUBKYPf8Yx/NKjLO30
+        W+c1PA/8aAWeyM2lGP9J8DwuIB8Ug7GFIj1OvCk4Dj4RvFz/gjfkevMz3qxaCCAa4YCJG+JSiKXz
+        70NcvrmiowiGecqOnhR09DrLJ6+RYnI+DZLb6g/ifvTT9H0IV5PqT7+/Lp3jh/Mash7uWdk+L0zB
+        Q5x5PyHqALfI4rDowxCY0hRC+rv50Hkf0SnDCh46fNL0OTWAWwu/N8LoYNsEy1HfXjCXrCa2Rlu0
+        nNBSIovDRktK0yleU1LJ9OXXlKeU2uQ51RsF4z4CSiwZhjWFhLleQfJCM1VJLK6ibMJgrV/xS6ar
+        rr10/TmEv8VTMj+cmhbke279mUDEVJFhjwI8K3DeRMqwg7pbA94/YwuHuMrf5VtG4CxChQ0/vvb9
+        T2n3STWDS9GfeEnu2D+QTr0CCHg8lyqJwqnwakU9+NjAPyltmpQufrXQqsyV2fnLaTeewemNIoTg
+        8Uh7Dl4RlioyZujf9kLxYl9UJxapAqekOEVL5QFwXuHtih71ggjR8otVX/N7q/KXnfzgJy0yIDTS
+        HbOWL1pV1bIls62GMUwnWVAbZwuCzv2sdpUqsUGaslIJFcnXbCYJNqgIGFDpSSl3B/CjzThvB61N
+        rlTLb4oNOnqfy9t4rWFTdZPf1W5Rp9Wi7oA51Sacuvy//xeH7DGrU3Zo2j5S5HE3AlrkM4DzBzjW
+        qWMH13lH4SHy7k9YSN5xkB754vJZ7Z/vXMIlpXKabtbsBzIE1jS0e6tK6jg4Nm9kaKkonWlHFbAz
+        eACAvFX2D3nQ0LVZRvJMcs4bHuJMs7Diq3yvqk1khcgkNbngG7jJ/Rg7Rfya0d6L/qRMG9rPcwcZ
+        NjAySGGjbus2Q5O+klg5yD6TECWTLm0+K8wOIaYVK1kaZUaxDCYIwFHXkdAsMHL1gTRGC/eYqHZV
+        EpfXfO2GuLrxUsOzK0Wa71bixEV8M0cR0vDYItuGlc5RLvGgbR72r9zAL9i/mFQ+JDrUqPBMSWeY
+        4MG5LFX+IENZmR/PJHsRZ05SPShIGpRLaLQie5FZ7TifjZU4SU8ylWyI98mShMhu/6dpjNsSdXTV
+        v+YINC05V954Doc3g73KQ0Rcw8YtFa+ukyTBcZH2dWApziqUJiJaO3MRYvExT5Uns43exbw7ofBe
+        BVg1wy8NdvKRchxV5KptEbEpF2yRuoqkhqCjxDVN3lwSpcyVmIKEmpZQcpCJ4BxXbheZodkbP73/
+        1blzBgjQT9qI1Bokp4iGsy5IdRr+5NS5Xw1JYlsNKH40sAhwW4GiRZeQW4EjeajfYfNEzrdtIOjf
+        nA69WdvBLZXAiJ7Zttt2SFSdio88m2XbjmTBKHy3tCPU3LnzNWgh3UdD6PZ6uLJZ/8vhys09gCt7
+        2FPC5V0mNIJQ/GSXJO6ucX5VrtXsAh3Hu4444O8WG1QVE2GdrM7Gc1zNG1ez/tnV2bw7DnpV5NCA
+        GRqacbcKyPoRf7raq9qdBDg/j+NvEdjYgYrq1nYhNfuB19lFYOKug2kIixMCBNZFH0vLxK8A4ufv
+        AzflKmfyp+2IRwnJkbns8/RDQa/qVmjwzCA0HjUCzGBwsIeYefIhAMQcn1WEz6g9g/8SJoIiEcwg
+        tpE6fDlXB9PeeA6X9urHuMoR6THlKfH7PLgfhUkP3Lp7ILPHLlL5GO9i4ZZmwLRrtae0zSpzUlxV
+        xzR6ngAJbVhH+ARUJ9+dfRpmkGlixhwKMuE13E+o1OfFZIB5/QkWoQJUcJOHQUUX+7zIkPbmqnFp
+        YlzS9lmv+6xDovJO9hBoMpvPbA7JYpItt4QeJIv1IR2dQqJYBdpe5O2eP79Caj717ecQ15PjPgqn
+        49yVcK9Mzy+1S93Wwclhq9bseaVyKYh/f/8zXuJP2vtesJZyQcsrXlJqy0vOK4yvrJyRGpkrE8QU
+        EdIHAKKhHIGjLl/FJxf3lRfuR8GbAk1TILzhFZsxrWuglBupXSIdQL15A8wIsffsdUbfKKd5uYRV
+        ge/N/pHvUch/Fav9BWwZPRx2tkvudUhZKSc4gvIrfDpNNlkcXiOiqHsLJHVuz0sVgnmJkPSyvhqH
+        HvxhiAAnxEwxzPSTh0MtylJg3usr5yUzgONikAIJb78krcx+oSqV7k+hoz+xfJAl6AqCfDzG1btY
+        SwtmA/kIY8lWfJWRUtg6/oVcL2OkG3/rnPz9ZHILlqOoXx0lk3FrCVb8LQZR8zPixV84TAwGf9Ne
+        czMpupEuklFCFNHU0qEUI1oVUQozsViOFOlPMry8/uVmMEETJet6xtMXoC9h3AiGzDbvMdtp3orC
+        9aH6oZo5L8ajudjig1a6PuRWQ3xgteuDWkA+YA0b4mXkX7EvTLm02Obvn6fNKbrDbT6C6dcaTqyR
+        WdXTVgkKhzUTSpgZr8zMqNLVPuBAZuLz5/8XEPlScIfiAAA=
+    headers:
+      Cache-control:
+      - private
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Mon, 14 Feb 2022 16:46:25 GMT
+      Link:
+      - <https://www.gnome.org/>; rel=shortlink
+      Server:
+      - nginx/1.18.0
+      Set-Cookie:
+      - b0aceef7c1fae53893d6fe73e8c2f26d=acb15c1b3af3d83a8fe779b68c00f8fb; path=/;
+        HttpOnly; Secure; SameSite=None
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.4.27
+      X-UA-Compatible:
+      - IE=edge
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_verification_status_website
+++ b/tests/cassettes/test_verification_status_website
@@ -79,20 +79,53 @@ interactions:
       X-GitHub-Media-Type:
       - github.v3; format=json
       X-GitHub-Request-Id:
-      - 996E:7F5F:65D0B5:FAA9C3:620A8648
+      - 8F34:2D7B:BBF4AF:1925F52:620A864A
       X-RateLimit-Limit:
       - '60'
       X-RateLimit-Remaining:
-      - '59'
+      - '54'
       X-RateLimit-Reset:
       - '1644860505'
       X-RateLimit-Resource:
       - core
       X-RateLimit-Used:
-      - '1'
+      - '6'
       X-XSS-Protection:
       - '0'
     status:
       code: 200
       message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: https://gnome.org/.well-known/org.flathub.VerifiedApps.txt
+  response:
+    body:
+      string: 'org.gnome.Maps'
+    headers:
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Mon, 14 Feb 2022 16:41:46 GMT
+      Server:
+      - nginx/1.18.0
+      Set-Cookie:
+      - 0235448947997ebd73869bdcdc930c7f=4aa7854b61011c78007aee2a1b227d9d; path=/;
+        HttpOnly; Secure; SameSite=None
+      Transfer-Encoding:
+      - chunked
+      X-Powered-By:
+      - PHP/7.4.27
+    status:
+      code: 200
+      message: Found
 version: 1

--- a/tests/main.py
+++ b/tests/main.py
@@ -315,35 +315,61 @@ def test_app_stats_by_non_existent_id():
 
 
 def test_verification_status():
-    response = client.get("/verification/some.app.id/status")
+    response = client.get("/verification/com.github.flathub.ExampleApp/status")
     expected = {
         "verified": False,
         "method": "none",
+        "detail": "repo_does_not_exist",
     }
     assert response.status_code == 200
     assert response.json() == expected
 
 
 def test_verification_available_method_website():
-    response = client.get("/verification/some.app.id/available-methods")
+    response = client.get("/verification/org.gnome.Maps/available-methods")
     expected = {
-        "methods": [{
-            "method": "website",
-            "website": "app.some",
-        }]
+        "methods": [
+            {
+                "method": "website",
+                "website": "gnome.org",
+            }
+        ]
     }
     assert response.status_code == 200
     assert response.json() == expected
 
 
-def test_verification_available_method_website():
-    response = client.get("/verification/com.github.flathub.ExampleApp/available-methods")
+def test_verification_available_method_github():
+    response = client.get(
+        "/verification/com.github.bilelmoussaoui.Authenticator/available-methods"
+    )
     expected = {
-        "methods": [{
-            "method": "login_provider",
-            "login_provider": "GitHub",
-            "login_name": "flathub",
-        }]
+        "methods": [
+            {
+                "method": "login_provider",
+                "login_provider": "GitHub",
+                "login_name": "bilelmoussaoui",
+            }
+        ]
+    }
+    assert response.status_code == 200
+    assert response.json() == expected
+
+
+def test_verification_available_method_multiple():
+    response = client.get("/verification/io.github.lainsce.Notejot/available-methods")
+    expected = {
+        "methods": [
+            {
+                "method": "website",
+                "website": "lainsce.github.io",
+            },
+            {
+                "method": "login_provider",
+                "login_provider": "GitHub",
+                "login_name": "lainsce",
+            },
+        ]
     }
     assert response.status_code == 200
     assert response.json() == expected

--- a/tests/main.py
+++ b/tests/main.py
@@ -319,18 +319,6 @@ def test_app_stats_by_non_existent_id():
 
 
 @vcr.use_cassette()
-def test_verification_status():
-    response = client.get("/verification/com.github.flathub.ExampleApp/status")
-    expected = {
-        "verified": False,
-        "method": "none",
-        "detail": "repo_does_not_exist",
-    }
-    assert response.status_code == 200
-    assert response.json() == expected
-
-
-@vcr.use_cassette()
 def test_verification_available_method_website():
     response = client.get("/verification/org.gnome.Maps/available-methods")
     expected = {
@@ -378,6 +366,53 @@ def test_verification_available_method_multiple():
                 "login_name": "lainsce",
             },
         ]
+    }
+    assert response.status_code == 200
+    assert response.json() == expected
+
+
+@vcr.use_cassette()
+def test_verification_status_dne():
+    response = client.get("/verification/com.github.flathub.ExampleApp/status")
+    expected = {
+        "verified": False,
+        "method": "none",
+        "detail": "repo_does_not_exist",
+    }
+    assert response.status_code == 200
+    assert response.json() == expected
+
+
+@vcr.use_cassette()
+def test_verification_status_invalid():
+    response = client.get("/verification/com.github/status")
+    expected = {
+        "verified": False,
+        "method": "none",
+        "detail": "malformed_app_id",
+    }
+    assert response.status_code == 200
+    assert response.json() == expected
+
+
+@vcr.use_cassette()
+def test_verification_status_website():
+    response = client.get("/verification/org.gnome.Maps/status")
+    expected = {
+        "verified": True,
+        "method": "website",
+        "website": "gnome.org",
+    }
+    assert response.status_code == 200
+    assert response.json() == expected
+
+
+@vcr.use_cassette()
+def test_verification_status_not_verified():
+    response = client.get("/verification/org.gnome.Calendar/status")
+    expected = {
+        "verified": False,
+        "method": "none",
     }
     assert response.status_code == 200
     assert response.json() == expected

--- a/tests/main.py
+++ b/tests/main.py
@@ -13,12 +13,16 @@ gi.require_version("OSTree", "1.0")
 from fastapi.testclient import TestClient
 from gi.repository import Gio, OSTree
 from lxml import etree
+import vcr
 
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(ROOT_DIR)
 
 workspace = None
 client = None
+
+
+vcr = vcr.VCR(cassette_library_dir="tests/cassettes")
 
 
 def _get_expected_json_result(test_name):
@@ -314,6 +318,7 @@ def test_app_stats_by_non_existent_id():
     assert response.json() == None
 
 
+@vcr.use_cassette()
 def test_verification_status():
     response = client.get("/verification/com.github.flathub.ExampleApp/status")
     expected = {
@@ -325,6 +330,7 @@ def test_verification_status():
     assert response.json() == expected
 
 
+@vcr.use_cassette()
 def test_verification_available_method_website():
     response = client.get("/verification/org.gnome.Maps/available-methods")
     expected = {
@@ -339,6 +345,7 @@ def test_verification_available_method_website():
     assert response.json() == expected
 
 
+@vcr.use_cassette()
 def test_verification_available_method_github():
     response = client.get(
         "/verification/com.github.bilelmoussaoui.Authenticator/available-methods"
@@ -356,6 +363,7 @@ def test_verification_available_method_github():
     assert response.json() == expected
 
 
+@vcr.use_cassette()
 def test_verification_available_method_multiple():
     response = client.get("/verification/io.github.lainsce.Notejot/available-methods")
     expected = {


### PR DESCRIPTION
Adds the website verification method and an endpoint for debugging this method.

---

Question about testing: The tests for this code rely on the GitHub API (it checks whether the repo really exists under the flathub org). It also depends on a few app IDs being there to test different scenarios (`org.gnome.Maps`, `com.github.bilelmoussaoui.Authenticator` which is currently archived, and `io.github.lainsce.Notejot`). Is this ok?