### PR TITLE
Add type to addstream

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -127,7 +127,9 @@ def get_json_key(key: str):
 
 
 def get_app_count() -> int:
-    return redis_conn.scard("apps:index")
+    return redis_conn.scard("types:desktop") + redis_conn.scard(
+        "types:console-application"
+    )
 
 
 def get_developers():

--- a/app/main.py
+++ b/app/main.py
@@ -123,8 +123,8 @@ def get_developer(
 
 
 @app.get("/appstream")
-def list_appstream():
-    return apps.list_appstream()
+def list_appstream(type: schemas.Type = schemas.Type.Desktop):
+    return apps.list_appstream(type)
 
 
 @app.get("/appstream/{appid}", status_code=200)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -14,3 +14,13 @@ class Category(str, Enum):
     Science = "Science"
     System = "System"
     Utility = "Utility"
+
+
+class Type(str, Enum):
+    All = "all"
+    Addon = "addon"
+    ConsoleApplication = "console-application"
+    Desktop = "desktop"
+    Generic = "generic"
+    Inputmethod = "inputmethod"
+    Runtime = "runtime"

--- a/app/utils.py
+++ b/app/utils.py
@@ -59,8 +59,7 @@ def appstream2dict(reponame: str):
     for component in root:
         app = {}
 
-        if component.attrib.get("type") != "desktop":
-            continue
+        app["type"] = component.attrib.get("type")
 
         descriptions = component.findall("description")
         if len(descriptions):

--- a/tests/results/test_appstream_by_appid.json
+++ b/tests/results/test_appstream_by_appid.json
@@ -1,4 +1,5 @@
 {
+  "type": "desktop",
   "description": "<p>Good at finding your way out of hard situations? Let's see! Try to make your way through an increasingly difficult path.</p>",
   "screenshots": [
     {
@@ -42,8 +43,12 @@
   "name": "Maze",
   "summary": "A simple maze game",
   "developer_name": "Sugar Labs Community",
-  "categories": ["Game"],
-  "kudos": ["HiDpiIcon"],
+  "categories": [
+    "Game"
+  ],
+  "kudos": [
+    "HiDpiIcon"
+  ],
   "project_license": "GPL-3.0-or-later",
   "launchable": {
     "value": "org.sugarlabs.Maze.desktop",


### PR DESCRIPTION
A remix of https://github.com/flathub/backend/pull/86 with only the type parts and a changed enpoint, so that we can show logged in devs their app(s) even if that app is a console application or similar.

This doesn't change, that we're only showing `desktop` apps to normal users. But this is probably needed for the work of the codethink people and might help fixing https://github.com/flathub/frontend/issues/227